### PR TITLE
Limit chart results

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -36,7 +36,7 @@ The project follows the Salesforce DX structure with source located under `force
 1. `getDatasets` retrieves dataset IDs when the component initializes.
 2. Dual list boxes and combo box capture filter selections from the user.
 3. Option queries apply the currently selected filters (excluding the field being queried) so that each filter only displays valid values.
-4. `executeQuery` runs SAQL queries for all charts using the selected filters.
+4. `executeQuery` runs SAQL queries for all charts using the selected filters and limits each result set to 20 rows.
 5. The first chart in each pair uses the filters as selected; the second chart applies the inverse of the `host` and `nation` filters.
 6. Updating filters triggers `filtersUpdated`, which refreshes every chart with new query data.
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -21,6 +21,7 @@ SAC Charts is a Lightning application for Salesforce that enables users to quick
    - The first chart in each pair shall use the selected filters directly.
    - The second chart in each pair shall apply the inverse of the `host` and `nation` filters while honoring `season` and `ski` selections.
    - Chart data shall refresh whenever the user updates filter selections and clicks **Render**.
+   - Each chart shall display no more than the top 20 results as determined by the query order.
 5. **User Interface**
    - The component shall expose a Lightning App Page, Record Page, and Home Page target as defined in the metadata file.
    - Chart content shall appear within `<lightning-card>` containers that include four `<div>` elements with classes `chart1`, `chart2`, `chart3`, and `chart4`.

--- a/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
+++ b/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
@@ -40,4 +40,11 @@ describe('c-dynamic-charts', () => {
         expect(chart3).not.toBeNull();
         expect(chart4).not.toBeNull();
     });
+
+    it('contains SAQL limit of 20 for each chart query', () => {
+        const fs = require('fs');
+        const file = fs.readFileSync(require.resolve('c/dynamicCharts'), 'utf8');
+        const matches = file.match(/limit q 20/g) || [];
+        expect(matches.length).toBe(4);
+    });
 });

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
@@ -109,7 +109,7 @@ export default class SacCharts extends LightningElement {
         saql += "q = group q by 'nation';\n";
         saql += "q = foreach q generate q.'nation' as nation, count(q) as Climbs;\n";
         saql += "q = order q by 'Climbs' desc;\n";
-        saql += 'q = limit q 2000;';
+        saql += 'q = limit q 20;';
         return { query: saql };
     }
 
@@ -123,7 +123,7 @@ export default class SacCharts extends LightningElement {
         saql += "q = group q by 'nation';\n";
         saql += "q = foreach q generate q.'nation' as nation, count(q) as Climbs;\n";
         saql += "q = order q by 'Climbs' desc;\n";
-        saql += 'q = limit q 2000;';
+        saql += 'q = limit q 20;';
         return { query: saql };
     }
 
@@ -136,7 +136,7 @@ export default class SacCharts extends LightningElement {
         saql += this.getFilters();
         saql += "q = group q by 'peakid';\n";
         saql += "q = foreach q generate q.'peakid' as peakid, min(q.'totdays') as A, percentile_disc(0.25) within group (order by q.'totdays') as B, percentile_disc(0.75) within group (order by q.'totdays') as C, max(q.'totdays') as D;\n";
-        saql += 'q = limit q 2000;';
+        saql += 'q = limit q 20;';
         return { query: saql };
     }
 
@@ -149,7 +149,7 @@ export default class SacCharts extends LightningElement {
         saql += this.getFilters({ inverseHosts: true, inverseNations: true });
         saql += "q = group q by 'peakid';\n";
         saql += "q = foreach q generate q.'peakid' as peakid, min(q.'totdays') as A, percentile_disc(0.25) within group (order by q.'totdays') as B, percentile_disc(0.75) within group (order by q.'totdays') as C, max(q.'totdays') as D;\n";
-        saql += 'q = limit q 2000;';
+        saql += 'q = limit q 20;';
         return { query: saql };
     }
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -3,6 +3,10 @@
     {
       "path": "force-app",
       "default": true
+    },
+    {
+      "path": "force-app/test",
+      "default": false
     }
   ],
   "name": "ApexChartDemo",


### PR DESCRIPTION
## Summary
- enforce SAQL limit of 20 rows in all chart queries
- document top-20 result limit in requirements and design docs
- update sfdx project to include test package
- add a Jest test ensuring the limit is present

## Testing
- `npm run test:unit`
- `sf project deploy start --source-dir force-app`

------
https://chatgpt.com/codex/tasks/task_e_684784d0dda48327a157b4c5fc16dc5b