### PR TITLE
Add multi-select picklist and update docs

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -30,12 +30,13 @@ The project follows the Salesforce DX structure with source located under `force
 - **dynamicCharts.js**: Core logic for loading datasets, handling filter selections, generating SAQL, cross-filtering available options, and rendering four charts with ApexCharts.
 - **dynamicCharts.html**: Presents filter controls and four chart containers arranged in two side-by-side pairs.
 - **dynamicCharts.js-meta.xml**: Exposes the component to App, Record, and Home pages.
+- **multiSelectPicklist**: Reusable search-based picklist used for the Season and Ski filters.
 - **DPOStateMachine.cls**: Placeholder Apex class reserved for future enhancements or server-side processing.
 - **chartRequirements.json**: Defines chart metadata such as type, dimensions, titles, colors, and effects used by the LWC.
 
 ## Data Flow
 1. `getDatasets` retrieves dataset IDs when the component initializes.
-2. Dual list boxes and combo box capture filter selections from the user.
+2. Dual list boxes capture `host` and `nation` selections while a reusable `multiSelectPicklist` component handles `season` and `ski` filters.
 3. Option queries apply the currently selected filters (excluding the field being queried) so that each filter only displays valid values.
 4. `executeQuery` runs SAQL queries for all charts using the selected filters and limits each result set to 20 rows.
 5. The first chart in each pair uses the filters as selected; the second chart applies the inverse of the `host` and `nation` filters.

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -9,8 +9,8 @@ SAC Charts is a Lightning application for Salesforce that enables users to quick
    - Only datasets of type `Default` or `Live` with license type `EinsteinAnalytics` shall be returned.
 2. **Filter Options**
    - Users shall filter chart results by `host`, `nation`, `season`, and `ski` attributes.
-   - Dual list boxes shall be provided for `host`, `nation`, and `season` selections.
-   - A combo box shall be provided for the `ski` selection with the choices **All**, **Yes**, and **No**.
+   - Dual list boxes shall be provided for `host` and `nation` selections.
+   - A reusable `multiSelectPicklist` component shall be used for `season` and `ski` selections. The ski picklist is limited to a single choice (**All**, **Yes**, or **No**).
    - Selecting a value in any filter shall refresh the remaining filter options so that only valid values are displayed.
 3. **Dynamic Query Generation**
    - The component shall build a SAQL query based on selected filter values.

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.html
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.html
@@ -22,22 +22,12 @@
                         onchange={handleNationChange}></lightning-dual-listbox>
                     </td>
                     <td width="25%">
-                        <lightning-dual-listbox name="season"
-                        label="Season"
-                        source-label="Available"
-                        selected-label="Selected"
-                        field-level-help="Select Seasons to filter to"
-                        options={seasonOptions}
-                        onchange={handleSeasonChange}></lightning-dual-listbox>
+                        <c-multi-select-picklist label="Season" query={seasonQueryString}
+                            value={seasonSelections} onchange={handleSeasonChange}></c-multi-select-picklist>
                     </td>
                     <td>
-                        <lightning-combobox
-                            name="progress"
-                            label="Ski"
-                            value="in all"
-                            placeholder="Select Ski"
-                            options={skiOptions}
-                            onchange={handleSkiChange}></lightning-combobox>
+                        <c-multi-select-picklist label="Ski" default-options={skiOptions}
+                            value={skiSelections} max-selections="1" onchange={handleSkiChange}></c-multi-select-picklist>
                     </td>
                 </tr>
                 <tr>

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
@@ -9,11 +9,10 @@ export default class SacCharts extends LightningElement {
     hostSelections = [];
     nationSelections = [];
     seasonSelections = [];
-    skiSelection = [];
+    skiSelections = [];
 
     hostOptions;
     nationOptions;
-    seasonOptions;
     skiOptions = [
         { label: 'All', value: 'in all' },
         { label: 'Yes', value: '== "Yes"' },
@@ -65,14 +64,14 @@ export default class SacCharts extends LightningElement {
         return undefined;
     }
 
-    get seasonQuery() {
+    get seasonQueryString() {
         if (this.datasetIds) {
             const id = this.datasetIds.exped;
             let saql = `q = load \"${id}\";\n`;
             saql += this.getFilters({ exclude: ['season'] });
             saql += "q = group q by 'season';\n";
             saql += "q = foreach q generate q.'season' as season;";
-            return { query: saql };
+            return saql;
         }
         return undefined;
     }
@@ -91,12 +90,6 @@ export default class SacCharts extends LightningElement {
         }
     }
 
-    @wire(executeQuery, { query: '$seasonQuery' })
-    onSeasonQuery({ data, error }) {
-        if (data) {
-            this.seasonOptions = data.results.records.map(r => ({ label: r.season, value: r.season }));
-        }
-    }
 
     // Chart query
     get climbsByCountryQuery() {
@@ -274,7 +267,7 @@ export default class SacCharts extends LightningElement {
         this.seasonSelections = event.detail.value;
     }
     handleSkiChange(event) {
-        this.skiSelection = event.detail.value;
+        this.skiSelections = event.detail.value;
     }
 
     filtersUpdated() {
@@ -299,8 +292,8 @@ export default class SacCharts extends LightningElement {
         if (this.seasonSelections.length > 0 && !exclude.includes('season')) {
             saql += `q = filter q by 'season' in ${JSON.stringify(this.seasonSelections)};\n`;
         }
-        if (this.skiSelection.length > 0 && !exclude.includes('ski')) {
-            saql += `q = filter q by 'ski' ${this.skiSelection};\n`;
+        if (this.skiSelections.length > 0 && !exclude.includes('ski')) {
+            saql += `q = filter q by 'ski' ${this.skiSelections[0]};\n`;
         }
         return saql;
     }

--- a/force-app/main/default/lwc/multiSelectPicklist/__tests__/multiSelectPicklist.test.js
+++ b/force-app/main/default/lwc/multiSelectPicklist/__tests__/multiSelectPicklist.test.js
@@ -1,0 +1,26 @@
+import { createElement } from 'lwc';
+import MultiSelectPicklist from 'c/multiSelectPicklist';
+
+describe('c-multi-select-picklist', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    it('tracks selected values via the value property', () => {
+        const element = createElement('c-multi-select-picklist', {
+            is: MultiSelectPicklist
+        });
+        element.defaultOptions = [
+            { id: '1', label: 'One' },
+            { id: '2', label: 'Two' }
+        ];
+        document.body.appendChild(element);
+
+        element.value = ['1'];
+        return Promise.resolve().then(() => {
+            expect(element.value).toEqual(['1']);
+        });
+    });
+});

--- a/force-app/main/default/lwc/multiSelectPicklist/multiSelectPicklist.html
+++ b/force-app/main/default/lwc/multiSelectPicklist/multiSelectPicklist.html
@@ -1,0 +1,42 @@
+<template>
+    <div class="slds-form-element">
+        <label class="slds-form-element__label" for="searchInput">{label}</label>
+        <div class="slds-combobox_container">
+            <div class="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click" onblur={handleBlur}>
+                <div class="slds-combobox__form-element" role="none">
+                    <lightning-input type="text" id="searchInput" value={searchTerm} onchange={handleSearch} onclick={toggleDropdown} placeholder={placeholder}></lightning-input>
+                </div>
+                <div if:true={isOpen} class="slds-dropdown slds-dropdown_length-with-icon-7 slds-dropdown_fluid" role="listbox">
+                    <div class="slds-p-horizontal_small slds-text-color_weak slds-text-title_caps">
+                        <a href="javascript:void(0);" onclick={selectAll}>Select All</a> |
+                        <a href="javascript:void(0);" onclick={clearAll}>Clear All</a>
+                    </div>
+                    <ul class="slds-listbox slds-listbox_vertical" role="presentation">
+                        <template for:each={filteredOptions} for:item="option">
+                            <li key={option.id} role="presentation" class="slds-listbox__item">
+                                <div class="slds-media">
+                                    <div class="slds-media__figure">
+                                        <lightning-input type="checkbox" checked={option.isChecked} data-id={option.id} onchange={handleSelect}></lightning-input>
+                                    </div>
+                                    <div class="slds-media__body">
+                                        <span class="slds-truncate" title={option.label}>{option.label}</span>
+                                    </div>
+                                </div>
+                            </li>
+                        </template>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="slds-m-top_x-small">
+            <template if:true={selectedItems.length}>
+                <template for:each={selectedItems} for:item="pill">
+                    <lightning-pill key={pill.id} label={pill.label} onremove={removePill} name={pill.id}></lightning-pill>
+                </template>
+            </template>
+            <template if:false={selectedItems.length}>
+                <span class="slds-text-color_weak">None Selected</span>
+            </template>
+        </div>
+    </div>
+</template>

--- a/force-app/main/default/lwc/multiSelectPicklist/multiSelectPicklist.js
+++ b/force-app/main/default/lwc/multiSelectPicklist/multiSelectPicklist.js
@@ -1,0 +1,150 @@
+import { LightningElement, api, track, wire } from 'lwc';
+import { executeQuery } from 'lightning/analyticsWaveApi';
+
+export default class MultiSelectPicklist extends LightningElement {
+    @api label;
+    @api maxSelections = 50;
+    @api placeholder = 'Search...';
+    @api query; // SAQL query to retrieve options if no options passed
+    @api defaultOptions = [];
+
+    @track options = [];
+    @track filteredOptions = [];
+    @track selectedItems = [];
+    @track searchTerm = '';
+    isOpen = false;
+
+    @api
+    get value() {
+        return this.selectedItems.map(item => item.id);
+    }
+
+    set value(val) {
+        if (Array.isArray(val)) {
+            this.selectedItems = this.options
+                .filter(opt => val.includes(opt.id))
+                .map(opt => ({ id: opt.id, label: opt.label }));
+            this.options.forEach(opt => {
+                opt.isChecked = val.includes(opt.id);
+            });
+            this.filterOptions();
+        }
+    }
+
+    connectedCallback() {
+        if (this.query) {
+            this.loadOptions();
+        } else {
+            this.options = this.defaultOptions.map(o => ({ ...o, isChecked: false }));
+            this.filteredOptions = [...this.options];
+        }
+    }
+
+    @wire(executeQuery, { query: '$builtQuery' })
+    wiredOptions({ data }) {
+        if (data && data.results) {
+            this.options = data.results.records.map(r => ({ id: r.id || r.label, label: r.label || r.value, isChecked: false }));
+            this.filterOptions();
+        }
+    }
+
+    get builtQuery() {
+        if (!this.query) {
+            return undefined;
+        }
+        return { query: this.query };
+    }
+
+    loadOptions() {
+        // Trigger wire service by referencing builtQuery getter
+        this.builtQuery;
+    }
+
+    handleSearch(event) {
+        this.searchTerm = event.target.value;
+        this.filterOptions();
+    }
+
+    handleBlur() {
+        this.isOpen = false;
+    }
+
+    toggleDropdown() {
+        this.isOpen = !this.isOpen;
+    }
+
+    filterOptions() {
+        const term = this.searchTerm.toLowerCase();
+        this.filteredOptions = this.options
+            .filter(opt => opt.label.toLowerCase().includes(term))
+            .slice(0, 100);
+    }
+
+    handleSelect(event) {
+        const id = event.target.dataset.id;
+        const option = this.options.find(o => o.id === id);
+        if (!option) return;
+        option.isChecked = event.target.checked;
+        if (option.isChecked) {
+            if (this.selectedItems.length >= this.maxSelections) {
+                option.isChecked = false;
+                this.showError();
+                return;
+            }
+            this.selectedItems.push({ id: option.id, label: option.label });
+        } else {
+            this.selectedItems = this.selectedItems.filter(item => item.id !== id);
+            this.clearError();
+        }
+        this.dispatchChange();
+    }
+
+    removePill(event) {
+        const id = event.target.name;
+        const option = this.options.find(o => o.id === id);
+        if (option) {
+            option.isChecked = false;
+        }
+        this.selectedItems = this.selectedItems.filter(item => item.id !== id);
+        this.dispatchChange();
+    }
+
+    selectAll() {
+        for (let opt of this.filteredOptions) {
+            if (!opt.isChecked) {
+                if (this.selectedItems.length >= this.maxSelections) {
+                    this.showError();
+                    break;
+                }
+                opt.isChecked = true;
+                this.selectedItems.push({ id: opt.id, label: opt.label });
+            }
+        }
+        this.dispatchChange();
+    }
+
+    clearAll() {
+        this.options.forEach(opt => opt.isChecked = false);
+        this.selectedItems = [];
+        this.clearError();
+        this.dispatchChange();
+    }
+
+    showError() {
+        const input = this.template.querySelector('lightning-input');
+        input.setCustomValidity(`Maximum of ${this.maxSelections} items can be selected.`);
+        input.reportValidity();
+    }
+
+    clearError() {
+        const input = this.template.querySelector('lightning-input');
+        input.setCustomValidity('');
+        input.reportValidity();
+    }
+
+    dispatchChange() {
+        this.placeholder = `${this.selectedItems.length} option(s) selected`;
+        this.filterOptions();
+        this.dispatchEvent(new CustomEvent('change', { detail: { value: this.value } }));
+    }
+}

--- a/force-app/main/default/lwc/multiSelectPicklist/multiSelectPicklist.js-meta.xml
+++ b/force-app/main/default/lwc/multiSelectPicklist/multiSelectPicklist.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- implement `multiSelectPicklist` LWC for searchable multiselect
- replace Season and Ski controls with new component
- document updated filter approach in design and requirements
- add Jest tests for the new picklist
- push source to default org

## Testing
- `npm run test:unit`
- `sf project deploy start --source-dir force-app`

------
https://chatgpt.com/codex/tasks/task_e_68478eb835f88327ba929a9e4d6315f6