### PR TITLE
Fix ApexCharts load error

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -43,7 +43,9 @@ The project follows the Salesforce DX structure with source located under `force
 6. Updating filters triggers `filtersUpdated`, which refreshes every chart with new query data.
 
 ## Dependencies
-- **ApexCharts**: Loaded from the static resource `ApexCharts` at runtime.
+- **ApexCharts**: Loaded from the static resource `ApexCharts` at runtime. The library
+  is cached with a shared promise so it loads only once, preventing `Apex._chartInstances`
+  errors when the component renders multiple times.
 - **lightning/analyticsWaveApi**: Provides `getDatasets` and `executeQuery` wire adapters.
 - **Salesforce LWC**: Standard library for creating Lightning Web Components.
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -17,7 +17,7 @@ SAC Charts is a Lightning application for Salesforce that enables users to quick
    - The component shall build a SAQL query based on selected filter values.
    - Filters shall be combined using the `filter q by` SAQL syntax.
 4. **Chart Rendering**
-   - The system shall load the ApexCharts library from a static resource.
+   - The system shall load the ApexCharts library from a static resource and cache it with a shared promise so it is loaded only once, preventing `Apex._chartInstances` errors.
    - Two bar charts and two box plots shall be displayed side by side in pairs.
    - The first chart in each pair shall use the selected filters directly.
    - The second chart in each pair shall apply the inverse of the `host` and `nation` filters while honoring `season` and `ski` selections.

--- a/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
+++ b/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
@@ -1,5 +1,16 @@
 import { createElement } from 'lwc';
 import DynamicCharts from 'c/dynamicCharts';
+import { loadScript } from 'lightning/platformResourceLoader';
+
+jest.mock('lightning/platformResourceLoader', () => {
+    return {
+        loadScript: jest.fn(() => Promise.resolve())
+    };
+});
+
+beforeAll(() => {
+    global.ApexCharts = jest.fn(() => ({ render: jest.fn(), updateOptions: jest.fn() }));
+});
 
 describe('c-dynamic-charts', () => {
     afterEach(() => {
@@ -46,5 +57,19 @@ describe('c-dynamic-charts', () => {
         const file = fs.readFileSync(require.resolve('c/dynamicCharts'), 'utf8');
         const matches = file.match(/limit q 20/g) || [];
         expect(matches.length).toBe(4);
+    });
+
+    it('loads ApexCharts script only once', () => {
+        const element1 = createElement('c-dynamic-charts', {
+            is: DynamicCharts
+        });
+        const element2 = createElement('c-dynamic-charts', {
+            is: DynamicCharts
+        });
+        document.body.appendChild(element1);
+        document.body.appendChild(element2);
+        return Promise.resolve().then(() => {
+            expect(loadScript.mock.calls.length).toBe(1);
+        });
     });
 });

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
@@ -3,6 +3,9 @@ import { getDatasets, executeQuery } from 'lightning/analyticsWaveApi';
 import apexchartJs from '@salesforce/resourceUrl/ApexCharts';
 import { loadScript } from 'lightning/platformResourceLoader';
 
+let apexChartsLoaded = false;
+let apexChartsPromise;
+
 export default class SacCharts extends LightningElement {
     datasetIds;
 
@@ -244,7 +247,14 @@ export default class SacCharts extends LightningElement {
     }
 
     initChart(selector, options, name) {
-        loadScript(this, apexchartJs + '/dist/apexcharts.js')
+        if (!apexChartsPromise) {
+            apexChartsPromise = loadScript(this, apexchartJs + '/dist/apexcharts.js')
+                .then(() => {
+                    apexChartsLoaded = true;
+                });
+        }
+
+        apexChartsPromise
             .then(() => {
                 const div = this.template.querySelector(selector);
                 const chart = new ApexCharts(div, options);


### PR DESCRIPTION
## Summary
- load ApexCharts library once and reuse across component instances
- add unit test ensuring script loads only once
- document ApexCharts caching in design and requirements docs

## Testing
- `npm run test:unit`
- `npm run lint` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684794a0d2c88327b7d5505d65e0b598