### PR TITLE
Handle empty chart queries

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -40,7 +40,7 @@ The project follows the Salesforce DX structure with source located under `force
 3. Option queries apply the currently selected filters (excluding the field being queried) so that each filter only displays valid values.
 4. `executeQuery` runs SAQL queries for all charts using the selected filters and limits each result set to 20 rows.
 5. The first chart in each pair uses the filters as selected; the second chart applies the inverse of the `host` and `nation` filters.
-6. Updating filters triggers `filtersUpdated`, which refreshes every chart with new query data.
+6. Updating filters triggers `filtersUpdated`, which refreshes every chart with new query data. When a query returns no records, chart updates are skipped so that ApexCharts does not throw runtime errors.
 
 ## Dependencies
 - **ApexCharts**: Loaded from the static resource `ApexCharts` at runtime. The library

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -24,6 +24,7 @@ SAC Charts is a Lightning application for Salesforce that enables users to quick
    - The second chart in each pair shall apply the inverse of the `host` and `nation` filters while honoring `season` and `ski` selections.
    - Chart data shall refresh whenever the user updates filter selections and clicks **Render**.
    - Each chart shall display no more than the top 20 results as determined by the query order.
+   - If a query returns no records, the chart shall remain unchanged to prevent ApexCharts runtime errors.
 5. **User Interface**
    - The component shall expose a Lightning App Page, Record Page, and Home Page target as defined in the metadata file.
    - Chart content shall appear within `<lightning-card>` containers that include four `<div>` elements identified by `ClimbsByCountry`, `ClimbsByCountryAO`, `TotalTimeByPeak`, and `TotalTimeByPeakAO`.

--- a/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
+++ b/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
@@ -72,4 +72,20 @@ describe('c-dynamic-charts', () => {
             expect(loadScript.mock.calls.length).toBe(1);
         });
     });
+
+    it('skips update when no results returned', () => {
+        const element = createElement('c-dynamic-charts', {
+            is: DynamicCharts
+        });
+        document.body.appendChild(element);
+
+        const chart = element.chartObject;
+        element.chartObject.ClimbsByCountry = {
+            updateOptions: jest.fn()
+        };
+
+        element.onClimbsByCountry({ data: { results: { records: [] } }, error: undefined });
+
+        expect(element.chartObject.ClimbsByCountry.updateOptions).not.toHaveBeenCalled();
+    });
 });

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
@@ -152,7 +152,7 @@ export default class SacCharts extends LightningElement {
 
     @wire(executeQuery, { query: '$climbsByCountryQuery' })
     onClimbsByCountry({ data, error }) {
-        if (data) {
+        if (data && data.results.records.length > 0) {
             const labels = [];
             const values = [];
             data.results.records.forEach(r => {
@@ -171,7 +171,7 @@ export default class SacCharts extends LightningElement {
 
     @wire(executeQuery, { query: '$climbsByCountryAoQuery' })
     onClimbsByCountryAo({ data, error }) {
-        if (data) {
+        if (data && data.results.records.length > 0) {
             const labels = [];
             const values = [];
             data.results.records.forEach(r => {
@@ -190,7 +190,7 @@ export default class SacCharts extends LightningElement {
 
     @wire(executeQuery, { query: '$totalTimeByPeakQuery' })
     onTotalTimeByPeak({ data, error }) {
-        if (data) {
+        if (data && data.results.records.length > 0) {
             const records = data.results.records.map(r => ({
                 x: r.peakid,
                 y: [
@@ -212,7 +212,7 @@ export default class SacCharts extends LightningElement {
 
     @wire(executeQuery, { query: '$totalTimeByPeakAoQuery' })
     onTotalTimeByPeakAo({ data, error }) {
-        if (data) {
+        if (data && data.results.records.length > 0) {
             const records = data.results.records.map(r => ({
                 x: r.peakid,
                 y: [


### PR DESCRIPTION
## Summary
- prevent ApexCharts errors when query returns no data
- document the empty-data handling in System Design and Requirements
- add jest test for skipping updates with empty results

## Testing
- `npm run test:unit --silent` *(fails: sfdx-lwc-jest not found)*
- `sfdcDeployer` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ff1080dc8327b1dbc2f450a9d379