### PR TITLE
Regenerate revEngCharts from LWC

### DIFF
--- a/revEngCharts.json
+++ b/revEngCharts.json
@@ -1,0 +1,109 @@
+{
+  "charts": [
+    {
+      "dashboard": "Unknown",
+      "id": "ClimbsByNation",
+      "type": "bar",
+      "title": "Climbs By Nation",
+      "fieldMappings": {
+        "nation": "nation",
+        "Climbs": "Climbs"
+      },
+      "saql": "q = load \"<datasetId>\";\n<filters>\nq = group q by 'nation';\nq = foreach q generate q.'nation' as nation, count(q) as Climbs;\nq = order q by 'Climbs' desc;\nq = limit q 20;",
+      "style": {
+        "seriesColors": "default",
+        "font": "default",
+        "effects": []
+      }
+    },
+    {
+      "dashboard": "Unknown",
+      "id": "ClimbsByNationAO",
+      "type": "bar",
+      "title": "Climbs By Nation AO",
+      "fieldMappings": {
+        "nation": "nation",
+        "Climbs": "Climbs"
+      },
+      "saql": "q = load \"<datasetId>\";\n<filters>\nq = group q by 'nation';\nq = foreach q generate q.'nation' as nation, count(q) as Climbs;\nq = order q by 'Climbs' desc;\nq = limit q 20;",
+      "style": {
+        "seriesColors": "default",
+        "font": "default",
+        "effects": []
+      }
+    },
+    {
+      "dashboard": "Unknown",
+      "id": "TimeByPeak",
+      "type": "box-and-whisker",
+      "title": "Time By Peak",
+      "fieldMappings": {
+        "peakid": "peakid",
+        "A": "A",
+        "B": "B",
+        "C": "C",
+        "D": "D"
+      },
+      "saql": "q = load \"<datasetId>\";\n<filters>\nq = group q by 'peakid';\nq = foreach q generate q.'peakid' as peakid, min(q.'totdays') as A, percentile_disc(0.25) within group (order by q.'totdays') as B, percentile_disc(0.75) within group (order by q.'totdays') as C, max(q.'totdays') as D;\nq = limit q 20;",
+      "style": {
+        "seriesColors": "default",
+        "font": "default",
+        "effects": []
+      }
+    },
+    {
+      "dashboard": "Unknown",
+      "id": "TimeByPeakAO",
+      "type": "box-and-whisker",
+      "title": "Time By Peak AO",
+      "fieldMappings": {
+        "peakid": "peakid",
+        "A": "A",
+        "B": "B",
+        "C": "C",
+        "D": "D"
+      },
+      "saql": "q = load \"<datasetId>\";\n<filters>\nq = group q by 'peakid';\nq = foreach q generate q.'peakid' as peakid, min(q.'totdays') as A, percentile_disc(0.25) within group (order by q.'totdays') as B, percentile_disc(0.75) within group (order by q.'totdays') as C, max(q.'totdays') as D;\nq = limit q 20;",
+      "style": {
+        "seriesColors": "default",
+        "font": "default",
+        "effects": []
+      }
+    },
+    {
+      "dashboard": "Unknown",
+      "id": "DaysPerPeak",
+      "type": "bar",
+      "title": "Days Per Peak",
+      "fieldMappings": {
+        "peakid": "peakid",
+        "A": "A",
+        "B": "B",
+        "C": "C",
+        "D": "D"
+      },
+      "saql": "q = load \"<datasetId>\";\n<filters>\nq = group q by 'peakid';\nq = foreach q generate q.'peakid' as peakid, min(q.'totdays') as A, percentile_disc(0.25) within group (order by q.'totdays') as B, percentile_disc(0.75) within group (order by q.'totdays') as C, max(q.'totdays') as D;\nq = order q by A asc;\nq = limit q 20;",
+      "style": {
+        "seriesColors": "default",
+        "font": "default",
+        "effects": []
+      }
+    },
+    {
+      "dashboard": "Unknown",
+      "id": "CampsByPeak",
+      "type": "bar",
+      "title": "Camps By Peak",
+      "fieldMappings": {
+        "peakid": "peakid",
+        "A": "A"
+      },
+      "saql": "q = load \"<datasetId>\";\n<filters>\nq = group q by 'peakid';\nq = foreach q generate q.'peakid' as peakid, avg(q.'camps') as A;\nq = order q by A desc;\nq = limit q 20;",
+      "style": {
+        "seriesColors": "default",
+        "font": "default",
+        "effects": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- generate `revEngCharts.json` based on current LWC

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6848d32cd3188327923aea162fecb85d