### PR TITLE
Fix horizontal bar chart options

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -3,7 +3,7 @@
 ## Overview
 
 SAC Charts is implemented as a Lightning Web Component (LWC) named `dynamicCharts`. The component obtains data from CRM Analytics using wire adapters, generates SAQL queries based on user-selected filters, and renders charts with the ApexCharts JavaScript library.
-Three groups of charts are rendered. The first group shows bar charts with and without the selected filters, the second group displays a horizontal bar chart of days per peak, and the third group contains box plots built from the same filter logic. Chart containers are named `ClimbsByNation`, `ClimbsByNationAO`, `CampsByPeak`, `DaysPerPeak`, `TimeByPeak`, and `TimeByPeakAO` to highlight how each relates.
+Three groups of charts are rendered. The first group shows bar charts with and without the selected filters, the second group displays a horizontal bar chart of days per peak, and the third group contains box plots built from the same filter logic. Chart containers are named `ClimbsByNation`, `ClimbsByNationAO`, `CampsByPeak`, `DaysPerPeak`, `TimeByPeak`, and `TimeByPeakAO` to highlight how each relates. The horizontal bar chart sets its categories on `yaxis.categories` as required by ApexCharts.
 
 The component now includes a sixth chart named `CampsByPeak` showing the average number of camps per peak. Chart containers are therefore `ClimbsByNation`, `ClimbsByNationAO`, `CampsByPeak`, `DaysPerPeak`, `TimeByPeak`, and `TimeByPeakAO`.
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -19,10 +19,11 @@ SAC Charts is a Lightning application for Salesforce that enables users to quick
    - Filters shall be combined using the `filter q by` SAQL syntax.
 4. **Chart Rendering**
    - The system shall load the ApexCharts library from a static resource.
-  - Four bar charts and two box plots shall be displayed in separate cards.
-   - The first chart in each pair shall use the selected filters directly.
-   - The second chart in each pair shall apply the inverse of the `host` and `nation` filters while honoring `season` and `ski` selections.
-   - Chart data shall refresh whenever the user updates filter selections and clicks **Render**.
+ - Four bar charts and two box plots shall be displayed in separate cards.
+  - The first chart in each pair shall use the selected filters directly.
+  - The second chart in each pair shall apply the inverse of the `host` and `nation` filters while honoring `season` and `ski` selections.
+  - Chart data shall refresh whenever the user updates filter selections and clicks **Render**.
+  - Categories for the horizontal bar chart shall be stored in `yaxis.categories`.
 5. **User Interface**
    - The component shall expose a Lightning App Page, Record Page, and Home Page target as defined in the metadata file.
    - Chart content shall appear within `<lightning-card>` containers that include `<div>` elements with classes matching the titles of charts within CRM Analytics dashboards.

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
@@ -279,7 +279,7 @@ export default class SacCharts extends LightningElement {
         maxVals.push(r.D);
       });
       const options = { ...this.chartBarOptions };
-      options.xaxis.categories = labels;
+      options.yaxis.categories = labels;
       options.series = [
         { name: "Min", data: minVals },
         { name: "Q1", data: q1Vals },
@@ -408,7 +408,7 @@ export default class SacCharts extends LightningElement {
     chart: { type: "bar", height: 410 },
     plotOptions: { bar: { horizontal: true } },
     series: [],
-    xaxis: { categories: [] },
+    yaxis: { categories: [] },
     noData: { text: "Loading..." }
   };
 


### PR DESCRIPTION
## Summary
- fix chartBarOptions to use `yaxis.categories`
- update DaysPerPeak chart logic accordingly
- clarify orientation handling in docs

## Testing
- `npm run test:unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849453ee3188327980f47effc9faaa6