### PR TITLE
Sync change requests with dashboard

### DIFF
--- a/changeRequests.json
+++ b/changeRequests.json
@@ -6,6 +6,11 @@
       "targetFile": "dynamicCharts.js",
       "mismatches": [
         {
+          "property": "dashboard",
+          "currentValue": "Unknown",
+          "expectedValue": "CR_02"
+        },
+        {
           "property": "title",
           "currentValue": "Climbs By Nation",
           "expectedValue": "Top 20 Climbs by Nation"
@@ -31,11 +36,14 @@
           "expectedValue": {
             "seriesColors": "#002060",
             "font": "default",
-            "effects": ["shadow"]
+            "effects": [
+              "shadow"
+            ]
           }
         }
       ],
       "instructions": [
+        "Update ClimbsByNation dashboard",
         "Update ClimbsByNation title",
         "Update ClimbsByNation fieldMappings",
         "Update ClimbsByNation style"
@@ -46,6 +54,11 @@
       "action": "update",
       "targetFile": "dynamicCharts.js",
       "mismatches": [
+        {
+          "property": "dashboard",
+          "currentValue": "Unknown",
+          "expectedValue": "CR_02"
+        },
         {
           "property": "title",
           "currentValue": "Time By Peak",
@@ -78,47 +91,17 @@
           "expectedValue": {
             "seriesColors": "#97C1DA,#002060",
             "font": "default",
-            "effects": ["shadow"]
+            "effects": [
+              "shadow"
+            ]
           }
         }
       ],
       "instructions": [
+        "Update TimeByPeak dashboard",
         "Update TimeByPeak title",
         "Update TimeByPeak fieldMappings",
         "Update TimeByPeak style"
-      ]
-    },
-    {
-      "chartId": "DaysPerPeak",
-      "action": "update",
-      "targetFile": "dynamicCharts.js",
-      "mismatches": [
-        {
-          "property": "title",
-          "currentValue": "Days Per Peak",
-          "expectedValue": "Days per Peak"
-        },
-        {
-          "property": "fieldMappings",
-          "currentValue": {
-            "peakid": "peakid",
-            "A": "A",
-            "B": "B",
-            "C": "C",
-            "D": "D"
-          },
-          "expectedValue": {
-            "A": "Min",
-            "B": "Q1",
-            "C": "Q3",
-            "D": "Max",
-            "peakid": "Peak ID"
-          }
-        }
-      ],
-      "instructions": [
-        "Update DaysPerPeak title",
-        "Update DaysPerPeak fieldMappings"
       ]
     },
     {
@@ -126,6 +109,11 @@
       "action": "update",
       "targetFile": "dynamicCharts.js",
       "mismatches": [
+        {
+          "property": "dashboard",
+          "currentValue": "Unknown",
+          "expectedValue": "CR_02"
+        },
         {
           "property": "title",
           "currentValue": "Camps By Peak",
@@ -152,15 +140,23 @@
           "expectedValue": {
             "seriesColors": "#175F68",
             "font": "default",
-            "effects": ["shadow"]
+            "effects": [
+              "shadow"
+            ]
           }
         }
       ],
       "instructions": [
+        "Update CampsByPeak dashboard",
         "Update CampsByPeak title",
         "Update CampsByPeak fieldMappings",
         "Update CampsByPeak style"
       ]
+    },
+    {
+      "chartId": "DaysPerPeak",
+      "action": "remove",
+      "targetFile": "dynamicCharts.js"
     }
   ]
 }

--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -3,15 +3,12 @@
 ## Overview
 
 SAC Charts is implemented as a Lightning Web Component (LWC) named `dynamicCharts`. The component obtains data from CRM Analytics using wire adapters, generates SAQL queries based on user-selected filters, and renders charts with the ApexCharts JavaScript library.
-Three groups of charts are rendered. The first group shows bar charts with and without the selected filters, the second group displays a horizontal bar chart of days per peak, and the third group contains box plots built from the same filter logic. Chart containers are named `ClimbsByNation`, `ClimbsByNationAO`, `CampsByPeak`, `DaysPerPeak`, `TimeByPeak`, and `TimeByPeakAO` to highlight how each relates. The horizontal bar chart sets its categories on `yaxis.categories` as required by ApexCharts.
-
-The component now includes a sixth chart named `CampsByPeak` showing the average number of camps per peak. Chart containers are therefore `ClimbsByNation`, `ClimbsByNationAO`, `CampsByPeak`, `DaysPerPeak`, `TimeByPeak`, and `TimeByPeakAO`.
+The latest dashboard definition consolidates the visualization set to three charts: `ClimbsByNation`, `TimeByPeak`, and `CampsByPeak`. Two bar charts display climb counts and average camps while a box plot shows days per peak. Each chart container name matches its dashboard title.
 
 Chart titles were updated in change request **CR-02**:
 
 - **Top 20 Climbs by Nation**
 - **Days per Peak by Top 20 Climbs**
-- **Days per Peak**
 - **Average Number of Camps per Peak**
 
 The project follows the Salesforce DX structure with source located under `force-app/main/default` and uses `sfdx-lwc-jest` for unit testing.

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -20,11 +20,9 @@ SAC Charts is a Lightning application for Salesforce that enables users to quick
 4. **Chart Rendering**
    - The system shall load the ApexCharts library from a static resource.
 
-- Four bar charts and two box plots shall be displayed in separate cards.
-- The first chart in each pair shall use the selected filters directly.
-- The second chart in each pair shall apply the inverse of the `host` and `nation` filters while honoring `season` and `ski` selections.
-- Chart data shall refresh whenever the user updates filter selections and clicks **Render**.
-- Chart titles shall reflect the latest dashboard definitions, including "Top 20 Climbs by Nation", "Days per Peak by Top 20 Climbs", "Days per Peak", and "Average Number of Camps per Peak".
+   - Three charts shall be displayed in separate cards.
+   - Chart data shall refresh whenever the user updates filter selections and clicks **Render**.
+   - Chart titles shall reflect the latest dashboard definitions, including "Top 20 Climbs by Nation", "Days per Peak by Top 20 Climbs", and "Average Number of Camps per Peak".
 
 5. **User Interface**
    - The component shall expose a Lightning App Page, Record Page, and Home Page target as defined in the metadata file.


### PR DESCRIPTION
## Summary
- generate new `changeRequests.json` by comparing dashboard charts with reverse-engineered LWC
- update design and requirements docs to remove the `DaysPerPeak` chart

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6849555f9164832793bf21bf03d385a2