### PR TITLE
Fix missing CampsByPeak AO chart

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -34,8 +34,8 @@ The project follows the Salesforce DX structure with source located under `force
 
 ### Key Components
 
-- **dynamicCharts.js**: Core logic for loading datasets, handling filter selections, generating SAQL, cross-filtering available options, and rendering five charts with ApexCharts.
-- **dynamicCharts.html**: Presents filter controls and five chart containers arranged in multiple cards.
+- **dynamicCharts.js**: Core logic for loading datasets, handling filter selections, generating SAQL, cross-filtering available options, and rendering six charts with ApexCharts.
+- **dynamicCharts.html**: Presents filter controls and six chart containers arranged in multiple cards.
 - **dynamicCharts.js-meta.xml**: Exposes the component to App, Record, and Home pages.
 - **DPOStateMachine.cls**: Placeholder Apex class reserved for future enhancements or server-side processing.
 - **charts.json**: Generated from the CRM Analytics dashboards to list supported charts. Primary charts are included, while `AO` variants are ignored.

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -25,6 +25,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - Chart data shall refresh whenever the user updates filter selections
    - Chart content and presentation shall be governed by CRMA dashboards referenced by a property in `charts.json`.
    - For every chart ID listed in `charts.json`, the markup shall include a pair of containers: one with the ID itself and a second with the `AO` suffix.
+   - The component currently displays three chart pairs: `ClimbsByNation`/`ClimbsByNationAO`, `TimeByPeak`/`TimeByPeakAO`, and `CampsByPeak`/`CampsByPeakAO`.
 5. **User Interface**
    - The component shall expose a Lightning App Page, Record Page, and Home Page target as defined in the metadata file.
    - Chart content shall appear within `<lightning-card>` containers that include `<div>` elements with classes matching the titles of charts within CRM Analytics dashboards.

--- a/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
+++ b/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
@@ -41,9 +41,11 @@ describe("c-dynamic-charts", () => {
     const chart3 = element.shadowRoot.querySelector("div.TimeByPeak");
     const chart4 = element.shadowRoot.querySelector("div.TimeByPeakAO");
     const chart6 = element.shadowRoot.querySelector("div.CampsByPeak");
+    const chart7 = element.shadowRoot.querySelector("div.CampsByPeakAO");
     expect(chart3).not.toBeNull();
     expect(chart4).not.toBeNull();
     expect(chart6).not.toBeNull();
+    expect(chart7).not.toBeNull();
   });
 
   it("initializes ApexCharts instances for all charts", async () => {
@@ -56,7 +58,7 @@ describe("c-dynamic-charts", () => {
     await Promise.resolve();
     await flushPromises();
 
-    expect(loadScript.mock.calls.length).toBeGreaterThanOrEqual(5);
+    expect(loadScript.mock.calls.length).toBeGreaterThanOrEqual(6);
     expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.html
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.html
@@ -63,27 +63,33 @@
   </lightning-card>
 
   <lightning-card title="Chart Series" icon-name="custom:custom1">
-    <lightning-layout>
-      <lightning-layout-item size="6">
-        <div
-          class="ClimbsByNation slds-var-m-around_medium"
-          lwc:dom="manual"
-        ></div>
-      </lightning-layout-item>
-      <lightning-layout-item size="6">
-        <div
-          class="ClimbsByNationAO slds-var-m-around_medium"
-          lwc:dom="manual"
-        ></div>
-      </lightning-layout-item>
-      <lightning-layout-item size="6">
-        <div
-          class="CampsByPeak slds-var-m-around_medium"
-          lwc:dom="manual"
-        ></div>
-      </lightning-layout-item>
-    </lightning-layout>
-  </lightning-card>
+      <lightning-layout>
+        <lightning-layout-item size="6">
+          <div
+            class="ClimbsByNation slds-var-m-around_medium"
+            lwc:dom="manual"
+          ></div>
+        </lightning-layout-item>
+        <lightning-layout-item size="6">
+          <div
+            class="ClimbsByNationAO slds-var-m-around_medium"
+            lwc:dom="manual"
+          ></div>
+        </lightning-layout-item>
+        <lightning-layout-item size="6">
+          <div
+            class="CampsByPeak slds-var-m-around_medium"
+            lwc:dom="manual"
+          ></div>
+        </lightning-layout-item>
+        <lightning-layout-item size="6">
+          <div
+            class="CampsByPeakAO slds-var-m-around_medium"
+            lwc:dom="manual"
+          ></div>
+        </lightning-layout-item>
+      </lightning-layout>
+    </lightning-card>
 
   <lightning-card title="Box Plot Series" icon-name="custom:custom2">
     <lightning-layout>

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
@@ -226,6 +226,21 @@ export default class SacCharts extends LightningElement {
     return { query: saql };
   }
 
+  get campsByPeakAOQuery() {
+    if (!this.datasetIds) {
+      return undefined;
+    }
+    const id = this.datasetIds.exped;
+    let saql = `q = load \"${id}\";\n`;
+    saql += this.getFilters({ inverseHosts: true, inverseNations: true });
+    saql += "q = group q by 'peakid';\n";
+    saql +=
+      "q = foreach q generate q.'peakid' as peakid, avg(q.'camps') as A;\n";
+    saql += "q = order q by A desc;\n";
+    saql += "q = limit q 20;";
+    return { query: saql };
+  }
+
   @wire(executeQuery, { query: "$climbsByNationQuery" })
   onClimbsByNation({ data, error }) {
     if (data) {
@@ -320,6 +335,26 @@ export default class SacCharts extends LightningElement {
     }
   }
 
+  @wire(executeQuery, { query: "$campsByPeakAOQuery" })
+  onCampsByPeakAO({ data, error }) {
+    if (data) {
+      const labels = [];
+      const values = [];
+      data.results.records.forEach((r) => {
+        labels.push(r.peakid);
+        values.push(r.A);
+      });
+      const options = { ...this.chartAOptions };
+      options.xaxis.categories = labels;
+      options.series = [{ name: "Avg Camps", data: values }];
+      if (this.chartObject.CampsByPeakAO) {
+        this.chartObject.CampsByPeakAO.updateOptions(
+          this.applySettings(options, "CampsByPeakAO")
+        );
+      }
+    }
+  }
+
   renderedCallback() {
     if (!this.chartObject.ClimbsByNation) {
       this.initChart(".ClimbsByNation", this.chartAOptions, "ClimbsByNation");
@@ -339,6 +374,9 @@ export default class SacCharts extends LightningElement {
     }
     if (!this.chartObject.CampsByPeak) {
       this.initChart(".CampsByPeak", this.chartAOptions, "CampsByPeak");
+    }
+    if (!this.chartObject.CampsByPeakAO) {
+      this.initChart(".CampsByPeakAO", this.chartAOptions, "CampsByPeakAO");
     }
   }
 
@@ -385,6 +423,7 @@ export default class SacCharts extends LightningElement {
     this.onTimeByPeak({ data: undefined, error: undefined });
     this.onTimeByPeakAO({ data: undefined, error: undefined });
     this.onCampsByPeak({ data: undefined, error: undefined });
+    this.onCampsByPeakAO({ data: undefined, error: undefined });
   }
 
   getFilters(options = {}) {


### PR DESCRIPTION
## Summary
- add missing CampsByPeakAO div
- wire new query and chart handling for CampsByPeakAO
- update tests for extra chart pair
- document six-chart layout in design and requirements

## Testing
- `npm test` *(fails: sfdx-lwc-jest not found)*
- `npm run prettier:verify` *(fails: Cannot find package 'prettier-plugin-apex')*

------
https://chatgpt.com/codex/tasks/task_e_684a0ccb2b2c83279115f4574cf8276a