### PR TITLE
Add sfdcAuthorize agent script

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -11,6 +11,7 @@ automation commands can locate it.
 
 | Agent Name                 | Script Path                                | Documentation                           |                       |
 | -------------------------- | ------------------------------------------ | --------------------------------------- | --------------------- |
+| **sfdcAuthorize**          | `scripts/agents/sfdcAuthorize.js`          | `docs/agents/sfdcAuthorize.md`          |                       |
 | **sfdcAuthorizer**         | `scripts/agents/sfdcAuthorizer.js`         | `docs/agents/sfdcAuthorizer.md`         |                       |
 | **dashboardRetriever**     | `scripts/agents/dashboardRetriever.js`     | `docs/agents/dashboardRetriever.md`     |                       |
 | **dashboardReader**        | `scripts/agents/dashboardReader.js`        | `docs/agents/dashboardReader.md`        |                       |
@@ -27,7 +28,7 @@ automation commands can locate it.
 
    **Sequence**:
 
-   1. **sfdcAuthorizer**
+   1. **sfdcAuthorize**
 
       * Authenticates with Salesforce and caches an access token.
    2. **dashboardRetriever**
@@ -73,7 +74,7 @@ automation commands can locate it.
 ### end-to-emnd\:charts
 
 
-   1. **sfdcAuthorizer**
+   1. **sfdcAuthorize**
 
       * Authenticates with Salesforce and caches an access token.
    2. **dashboardRetriever**

--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -58,6 +58,7 @@ The project follows the Salesforce DX structure with source located under `force
 - **ApexCharts**: Loaded from the static resource `ApexCharts` at runtime.
 - **lightning/analyticsWaveApi**: Provides `getDatasets` and `executeQuery` wire adapters.
 - **Salesforce LWC**: Standard library for creating Lightning Web Components.
+- **sfdcAuthorize**: Node script that performs JWT-based authentication so other automation agents can access the org.
 
 ## Testing
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -42,6 +42,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - Chart rendering shall occur within one second after the ApexCharts library loads and the SAQL query completes.
 2. **Security**
    - The LWC shall operate with sharing enforced through Salesforce security mechanisms.
+   - A Node script named `sfdcAuthorize` shall authenticate to Salesforce via JWT and set the default CLI username for deployment and testing automation.
 3. **Maintainability**
    - Code shall be written in modern JavaScript and Apex standards to ease future modifications.
 4. **Extensibility**

--- a/docs/agents/lwcTester.md
+++ b/docs/agents/lwcTester.md
@@ -8,7 +8,7 @@ Automates building, maintaining, and enhancing Jest-based unit and integration t
 
 ## Inputs
 
-- Authenticated Salesforce org via `sfdcAuthorizer`.
+- Authenticated Salesforce org via `sfdcAuthorize`.
 - Source code for the `dynamicCharts` component.
 - Optional flags:
   - `--unit`: Run Jest unit tests only.
@@ -17,7 +17,7 @@ Automates building, maintaining, and enhancing Jest-based unit and integration t
 
 ## Behavior
 
-1. **Authenticate**: Verifies Salesforce org authentication via `sfdcAuthorizer`.
+1. **Authenticate**: Verifies Salesforce org authentication via `sfdcAuthorize`.
 2. **Install & Update Tooling**: Installs/updates devDependencies (`sfdx-lwc-jest`, `apexcharts`, `jest-canvas-mock`). fileciteturn1file0
 3. **Scaffold Test Structure**: Creates `test/lwcTester/` with `unit/`, `integration/`, and `__mocks__/`.
 4. **Generate & Update Test Templates**: For each chart definition in `dynamicCharts.js` or `charts.json`, generates or refreshes parameterized Jest test files, verifying SAQL assembly, ApexCharts instantiation, filter UI interactions, and snapshot updates. fileciteturn1file0
@@ -29,7 +29,7 @@ Automates building, maintaining, and enhancing Jest-based unit and integration t
 
 ## Preconditions
 
-- Salesforce org authenticated via `sfdcAuthorizer`.
+- Salesforce org authenticated via `sfdcAuthorize`.
 - Valid `jest.config.js` in project root with appropriate module mappings and setup files. fileciteturn1file0
 
 ## Dependencies

--- a/docs/agents/sfdcAuthorize.md
+++ b/docs/agents/sfdcAuthorize.md
@@ -1,0 +1,37 @@
+# sfdcAuthorize Agent
+
+**Script Path**: `scripts/agents/sfdcAuthorize.js`
+
+## Description
+
+The `sfdcAuthorize` agent performs a JWT-based login using the Salesforce CLI. It sets the default username for subsequent automation commands so other agents can interact with the target org.
+
+## Inputs
+
+- Environment variables:
+  - `SFDC_USERNAME`: Username of the Salesforce integration user.
+  - `SFDC_CLIENT_ID`: Connected App consumer key.
+  - `SFDC_LOGIN_URL` (optional): Login URL, defaults to `https://login.salesforce.com`.
+- `jwt.key`: Private key used for the JWT flow.
+
+## Behavior
+
+1. Validate required environment variables and presence of `jwt.key`.
+2. Execute `sfdx auth:jwt:grant` with the provided parameters.
+3. On success, the authenticated org becomes the default username for the CLI.
+4. Exit with a non-zero code and error message on failure.
+
+## Dependencies
+
+- Salesforce CLI (`sfdx`) installed and accessible in the PATH.
+- Node.js ≥ 14.
+
+## CLI Usage
+
+```bash
+node scripts/agents/sfdcAuthorize.js
+```
+
+## Output
+
+- Authenticated Salesforce CLI session with the default username set.

--- a/docs/agents/sfdcDeployer.md
+++ b/docs/agents/sfdcDeployer.md
@@ -4,11 +4,11 @@
 
 ## Description
 
-The `sfdcDeployer` agent orchestrates the deployment of Salesforce metadata (Lightning Web Components, Apex classes, static resources, etc.) to your target org. It leverages `sfdcAuthorizer` for authentication and uses the Salesforce CLI under the hood to perform robust, repeatable deployments with error handling and reporting.
+The `sfdcDeployer` agent orchestrates the deployment of Salesforce metadata (Lightning Web Components, Apex classes, static resources, etc.) to your target org. It leverages `sfdcAuthorize` for authentication and uses the Salesforce CLI under the hood to perform robust, repeatable deployments with error handling and reporting.
 
 ## Inputs
 
-- Authenticated Salesforce org via `sfdcAuthorizer`.
+- Authenticated Salesforce org via `sfdcAuthorize`.
 - Metadata source directory (e.g., `force-app/main/default`).
 - Optional flags:
   - `--checkonly` (`-c`): Perform a validation deployment without committing changes.
@@ -17,7 +17,7 @@ The `sfdcDeployer` agent orchestrates the deployment of Salesforce metadata (Lig
 
 ## Behavior
 
-1. **Authenticate**: Confirms valid session with Salesforce org via `sfdcAuthorizer`.
+1. **Authenticate**: Confirms valid session with Salesforce org via `sfdcAuthorize`.
 2. **Validate**: Optionally runs `sfdx force:source:deploy --checkonly` to catch errors early.
 3. **Deploy**: Executes `sfdx force:source:deploy` on the specified metadata directory.
 4. **Monitor**: Polls deployment status until completion or timeout, respecting `--wait`.
@@ -29,7 +29,7 @@ The `sfdcDeployer` agent orchestrates the deployment of Salesforce metadata (Lig
 - **Salesforce CLI** (`sfdx`) installed and configured.
 - **Node.js** ≥ 14.
 - **fs-extra** for file system operations.
-- **sfdcAuthorizer** agent for authentication.
+- **sfdcAuthorize** agent for authentication.
 
 ## CLI Usage
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier:verify": "prettier --check \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
     "postinstall": "husky install",
     "precommit": "lint-staged",
-    "generate:charts": "node scripts/agents/sfdcAuthorizer.js && node scripts/agents/dashboardRetriever.js && node scripts/agents/dashboardReader.js && node scripts/agents/lwcReader.js && node scripts/agents/changeRequestGenerator.js",
+    "generate:charts": "node scripts/agents/sfdcAuthorize.js && node scripts/agents/dashboardRetriever.js && node scripts/agents/dashboardReader.js && node scripts/agents/lwcReader.js && node scripts/agents/changeRequestGenerator.js",
     "sync:charts": "node scripts/agents/syncCharts.js",
     "deploy:charts": "npm run test:unit && node scripts/agents/lwcTester.js && node scripts/agents/sfdcDeployer.js"
   },
@@ -34,7 +34,8 @@
     "jest-canvas-mock": "^2.5.2",
     "lint-staged": "^15.1.0",
     "prettier": "^3.1.0",
-    "prettier-plugin-apex": "^2.0.1"
+    "prettier-plugin-apex": "^2.0.1",
+    "sfdx-lwc-jest": "^10.10.10"
   },
   "lint-staged": {
     "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [

--- a/scripts/agents/sfdcAuthorize.js
+++ b/scripts/agents/sfdcAuthorize.js
@@ -1,0 +1,36 @@
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+function authorize() {
+  const username = process.env.SFDC_USERNAME;
+  const clientId = process.env.SFDC_CLIENT_ID;
+  const loginUrl = process.env.SFDC_LOGIN_URL || 'https://login.salesforce.com';
+  const keyFile = path.resolve(__dirname, '..', '..', 'jwt.key');
+
+  if (!username || !clientId) {
+    console.error('SFDC_USERNAME and SFDC_CLIENT_ID environment variables are required');
+    process.exitCode = 1;
+    return;
+  }
+  if (!fs.existsSync(keyFile)) {
+    console.error(`JWT key file missing at ${keyFile}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const cmd = `sfdx auth:jwt:grant --clientid ${clientId} --jwtkeyfile ${keyFile} ` +
+    `--username ${username} --instanceurl ${loginUrl} --setdefaultusername`;
+  try {
+    execSync(cmd, { stdio: 'inherit' });
+  } catch (err) {
+    console.error('Authorization failed');
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  authorize();
+}
+
+module.exports = authorize;

--- a/test/sfdcAuthorize.test.js
+++ b/test/sfdcAuthorize.test.js
@@ -1,0 +1,28 @@
+const path = require('path');
+jest.mock('child_process', () => ({ execSync: jest.fn() }));
+const { execSync } = require('child_process');
+
+describe('sfdcAuthorize', () => {
+  const originalEnv = { ...process.env };
+  const scriptPath = '../scripts/agents/sfdcAuthorize';
+  afterEach(() => {
+    jest.resetModules();
+    Object.assign(process.env, originalEnv);
+  });
+
+  test('builds correct sfdx command with env vars', () => {
+    process.env.SFDC_USERNAME = 'test@example.com';
+    process.env.SFDC_CLIENT_ID = '123456';
+    process.env.SFDC_LOGIN_URL = 'https://test.salesforce.com';
+
+    const authorize = require(scriptPath);
+    authorize();
+
+    const keyPath = path.resolve(__dirname, '..', 'jwt.key');
+    const expected =
+      `sfdx auth:jwt:grant --clientid 123456 --jwtkeyfile ${keyPath} ` +
+      '--username test@example.com --instanceurl https://test.salesforce.com --setdefaultusername';
+
+    expect(execSync).toHaveBeenCalledWith(expected, { stdio: 'inherit' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement new `sfdcAuthorize` agent to handle JWT login
- document the agent and update agent listings
- use the agent in workflows and npm scripts
- mention `sfdcAuthorize` in design and requirements
- update deployer and tester docs
- add Jest test for the new script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a1e6192c883279799f635c9576dc5