### PR TITLE
Load ApexCharts once for all charts

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -55,7 +55,7 @@ The project follows the Salesforce DX structure with source located under `force
 
 ## Dependencies
 
-- **ApexCharts**: Loaded from the static resource `ApexCharts` at runtime.
+- **ApexCharts**: Loaded once from the static resource `ApexCharts` on first render and reused for all charts.
 - **lightning/analyticsWaveApi**: Provides `getDatasets` and `executeQuery` wire adapters.
 - **Salesforce LWC**: Standard library for creating Lightning Web Components.
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -18,7 +18,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - The component shall build a SAQL query based on selected filter values.
    - Filters shall be combined using the `filter q by` SAQL syntax.
 4. **Chart Rendering**
-   - The system shall load the ApexCharts library from a static resource.
+   - The system shall load the ApexCharts library from a static resource only once during component initialization.
    - All charts shall be shown in pairs side-by-side:
      - The original chart bound to the filters so that it is applying a positive filter
      - A clone of the original chart with `AO` appended to the ID which shows 'All Others' or the inverse (!=) of the filters applied

--- a/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
+++ b/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
@@ -54,11 +54,11 @@ describe("c-dynamic-charts", () => {
     });
     document.body.appendChild(element);
 
-    const errorSpy = jest.spyOn(console, 'error');
+    const errorSpy = jest.spyOn(console, "error");
     await Promise.resolve();
     await flushPromises();
 
-    expect(loadScript.mock.calls.length).toBeGreaterThanOrEqual(6);
+    expect(loadScript).toHaveBeenCalledTimes(1);
     expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
@@ -3,6 +3,8 @@ import { getDatasets, executeQuery } from "lightning/analyticsWaveApi";
 import apexchartJs from "@salesforce/resourceUrl/ApexCharts";
 import { loadScript } from "lightning/platformResourceLoader";
 
+let apexChartsPromise;
+
 export default class SacCharts extends LightningElement {
   datasetIds;
 
@@ -330,7 +332,11 @@ export default class SacCharts extends LightningElement {
     }
     this._chartsInitialized = true;
 
-    loadScript(this, apexchartJs + "/dist/apexcharts.js")
+    if (!apexChartsPromise) {
+      apexChartsPromise = loadScript(this, apexchartJs + "/dist/apexcharts.js");
+    }
+
+    apexChartsPromise
       .then(() => {
         // initialize all six charts once the script is loaded
         this.initChart(".ClimbsByNation", this.chartAOptions, "ClimbsByNation");


### PR DESCRIPTION
## Summary
- ensure ApexCharts is loaded only once by reusing a shared promise
- update test expectation for single load
- document single-load behavior in design and requirements

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_684a243549f883278436afe9c06170ef