### PR TITLE
Update sfdcAuthorizer for local jwt.key

### DIFF
--- a/docs/agents/sfdcAuthorizer.md
+++ b/docs/agents/sfdcAuthorizer.md
@@ -30,12 +30,12 @@ fi
 
 ## Behavior
 
-1. Validate required environment variables and presence of `jwt.key`.
+1. Validate required environment variables and presence of the `jwt.key` file at the project root.
 2. Execute the JWT auth flow:
    ```bash
    sf org login jwt \
      --client-id $SFDC_CLIENT_ID \
-     --jwt-key-file <temp-key-path> \
+     --jwt-key-file ./jwt.key \
      --username $SFDC_USERNAME \
      --instance-url $SFDC_LOGIN_URL \
      --set-default

--- a/scripts/agents/sfdcAuthorizer.js
+++ b/scripts/agents/sfdcAuthorizer.js
@@ -1,8 +1,7 @@
 // scripts/agents/sfdcAuthorizer.js
-// Loads JWT key from Base64 env var or .env fallback without external modules
-// Uses the Salesforce CLI JWT flow via shell
+// Reads environment variables from a local .env file if present
+// Uses an existing jwt.key to run the Salesforce CLI JWT auth flow
 
-const os = require("os");
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
@@ -33,21 +32,17 @@ function authorize() {
   const username = process.env.SFDC_USERNAME;
   const clientId = process.env.SFDC_CLIENT_ID;
   const loginUrl = process.env.SFDC_LOGIN_URL || "https://login.salesforce.com";
-  const keyB64 = process.env.SF_JWT_KEY_BASE64;
-
-  if (!username || !clientId || !keyB64) {
+  if (!username || !clientId) {
     console.error(
-      "Error: SFDC_USERNAME, SFDC_CLIENT_ID, and SF_JWT_KEY_BASE64 must be set"
+      "Error: SFDC_USERNAME and SFDC_CLIENT_ID must be set"
     );
     process.exit(1);
   }
 
-  // Write the JWT key to a temp file
-  const keyFile = path.join(os.tmpdir(), "jwt.key");
-  try {
-    fs.writeFileSync(keyFile, Buffer.from(keyB64, "base64"));
-  } catch (err) {
-    console.error("Failed to write JWT key:", err);
+  // Path to the jwt.key generated during session setup
+  const keyFile = path.resolve(process.cwd(), "jwt.key");
+  if (!fs.existsSync(keyFile)) {
+    console.error("Error: jwt.key not found at project root");
     process.exit(1);
   }
 

--- a/test/sfdcAuthorizer.test.js
+++ b/test/sfdcAuthorizer.test.js
@@ -10,7 +10,7 @@ describe("sfdcAuthorizer", () => {
     Object.assign(process.env, originalEnv);
   });
 
-  test("builds correct sfdx command with env vars", () => {
+  test("builds correct sf command with env vars", () => {
     process.env.SFDC_USERNAME = "test@example.com";
     process.env.SFDC_CLIENT_ID = "123456";
     process.env.SFDC_LOGIN_URL = "https://test.salesforce.com";
@@ -20,8 +20,8 @@ describe("sfdcAuthorizer", () => {
 
     const keyPath = path.resolve(__dirname, "..", "jwt.key");
     const expected =
-      `sfdx auth:jwt:grant --clientid 123456 --jwtkeyfile ${keyPath} ` +
-      "--username test@example.com --instanceurl https://test.salesforce.com --setdefaultusername";
+      `sf org login jwt --client-id 123456 --jwt-key-file ${keyPath} ` +
+      "--username test@example.com --instance-url https://test.salesforce.com --set-default";
 
     expect(execSync).toHaveBeenCalledWith(expected, { stdio: "inherit" });
   });


### PR DESCRIPTION
## Summary
- update sfdcAuthorizer agent to use precreated `jwt.key`
- update docs to match new auth flow
- update jest test for new path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684aeaaf4b9883278725c6eb6122c900