### PR TITLE
Implement dashboardRetriever agent

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -59,6 +59,7 @@ The project follows the Salesforce DX structure with source located under `force
 - **lightning/analyticsWaveApi**: Provides `getDatasets` and `executeQuery` wire adapters.
 - **Salesforce LWC**: Standard library for creating Lightning Web Components.
 - **sfdcAuthorizer**: Node script that performs JWT-based authentication so other automation agents can access the org.
+- **dashboardRetriever**: Downloads dashboard state JSON via the Salesforce CLI so parsing agents can generate `charts.json`. When a dashboard label is supplied, it queries the CRM Analytics REST API to determine the API name before export.
 
 ## Testing
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -9,15 +9,19 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
 1. **Dataset Retrieval**
    - The system shall fetch available CRM Analytics datasets using the `getDatasets` wire adapter.
    - Only datasets of type `Default` or `Live` with license type `EinsteinAnalytics` shall be returned.
-2. **Filter Options**
+2. **Dashboard Retrieval**
+   - A `dashboardRetriever` script shall export dashboard state JSON using the Salesforce CLI.
+   - If only a dashboard label is provided, the script shall query the CRM Analytics REST API using `SF_INSTANCE_URL` and `SF_ACCESS_TOKEN` environment variables to resolve the dashboard's API name.
+   - Retrieved files shall be written to a configurable output directory (default `tmp`).
+3. **Filter Options**
    - Users shall filter chart results by `host`, `nation`, `season`, and `ski` attributes.
    - Dual list boxes shall be provided for `host`, `nation`, and `season` selections.
    - A combo box shall be provided for the `ski` selection with the choices **All**, **Yes**, and **No**.
    - Selecting a value in any filter shall refresh the remaining filter options so that only valid values are displayed.
-3. **Dynamic Query Generation**
+4. **Dynamic Query Generation**
    - The component shall build a SAQL query based on selected filter values.
    - Filters shall be combined using the `filter q by` SAQL syntax.
-4. **Chart Rendering**
+5. **Chart Rendering**
    - The system shall load the ApexCharts library from a static resource only once during component initialization.
    - All charts shall be shown in pairs side-by-side:
      - The original chart bound to the filters so that it is applying a positive filter
@@ -27,12 +31,12 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - For every chart ID listed in `charts.json`, the markup shall include a pair of containers: one with the ID itself and a second with the `AO` suffix.
    - The component currently displays three chart pairs: `ClimbsByNation`/`ClimbsByNationAO`, `TimeByPeak`/`TimeByPeakAO`, and `CampsByPeak`/`CampsByPeakAO`.
    - Charts configured with a `shadow` effect shall display drop shadows using the ApexCharts `chart.dropShadow` option.
-5. **User Interface**
+6. **User Interface**
    - The component shall expose a Lightning App Page, Record Page, and Home Page target as defined in the metadata file.
    - Chart content shall appear within `<lightning-card>` containers that include `<div>` elements with classes matching the titles of charts within CRM Analytics dashboards.
-6. **Compatibility**
+7. **Compatibility**
    - The application shall be compatible with Salesforce API version 59.0 as specified in the `sfdx-project.json` configuration.
-7. **Change Request Generation**
+8. **Change Request Generation**
    - The system shall compare `charts.json` with `revEngCharts.json` and output `changeRequests.json` listing required code updates.
    - A script shall convert `changeRequests.json` into a human-readable `changeRequestInstructions.txt` file for developers, translating style changes into their corresponding ApexCharts option paths.
 

--- a/docs/agents/dashboardRetriever.md
+++ b/docs/agents/dashboardRetriever.md
@@ -1,0 +1,53 @@
+# dashboardRetriever
+
+> Fetches a CRM Analytics dashboard state JSON using the Salesforce CLI.
+
+## Script Path
+
+`scripts/agents/dashboardRetriever.js`
+
+## Description
+
+The `dashboardRetriever` agent downloads the JSON representation of a CRM Analytics dashboard so that downstream agents can parse it. It relies on the Salesforce CLI command `analytics:dashboard:export` to retrieve the dashboard state. When only a dashboard label is supplied, the script first queries the CRM Analytics REST API to look up the dashboard's API name.
+
+## CLI Options
+
+- `--dashboard-api-name <dashboardApiName>`: DeveloperName of the dashboard to export.
+- `--dashboard-label <label>`: Human readable label used to look up the dashboard API name.
+- `--output-dir <directory>` (optional, default: `tmp`): Directory where the dashboard JSON file will be written.
+- `-h, --help`: Display basic usage information.
+
+## Inputs
+
+- `dashboardApiName`: DeveloperName of the dashboard.
+- `dashboardLabel`: Label used when the API name isn't known.
+- _(Optional)_ `outputDir`: Directory in which to place the exported JSON file.
+
+## Behavior
+
+1. Ensure either `dashboardApiName` or `dashboardLabel` is provided.
+2. If only `dashboardLabel` is supplied, query the REST API using `SF_ACCESS_TOKEN` and `SF_INSTANCE_URL` to find the corresponding API name.
+3. Create `outputDir` if it does not exist.
+4. Execute the Salesforce CLI command:
+   ```bash
+   sf analytics:dashboard:export --name <dashboardApiName> --output-dir <outputDir>
+   ```
+5. Exit with a non‑zero code on command failure.
+
+## Preconditions
+
+- Salesforce CLI (`sf`) is installed and authenticated via the `sfdcAuthorizer` agent.
+
+## Output
+
+- A dashboard state JSON file named `<dashboardApiName>.json` in the specified directory.
+
+## Example
+
+```bash
+# Using API name directly
+node scripts/agents/dashboardRetriever.js --dashboard-api-name CR-02 --output-dir tmp
+
+# Using dashboard label lookup
+node scripts/agents/dashboardRetriever.js --dashboard-label "Climbs By Nation" --output-dir tmp
+```

--- a/scripts/agents/dashboardRetriever.js
+++ b/scripts/agents/dashboardRetriever.js
@@ -1,0 +1,73 @@
+// scripts/agents/dashboardRetriever.js
+// Retrieves a CRM Analytics dashboard state JSON using the Salesforce CLI
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+function lookupApiNameByLabel(label) {
+  const token = process.env.SF_ACCESS_TOKEN;
+  const instance = process.env.SF_INSTANCE_URL;
+  const apiVersion = process.env.SF_API_VERSION || "59.0";
+
+  if (!token || !instance) {
+    throw new Error("SF_ACCESS_TOKEN and SF_INSTANCE_URL must be set");
+  }
+
+  const url = `${instance}/services/data/v${apiVersion}/wave/dashboards`;
+  const curlCmd = `curl -s -H "Authorization: Bearer ${token}" ${url}`;
+  const output = execSync(curlCmd, { encoding: "utf8" });
+  const dashboards = JSON.parse(output).dashboards || [];
+  const match = dashboards.find((d) => d.label === label);
+  if (!match) {
+    throw new Error(`Dashboard with label ${label} not found`);
+  }
+  return match.name;
+}
+
+function retrieveDashboard({
+  dashboardApiName,
+  dashboardLabel,
+  outputDir = "tmp"
+}) {
+  if (!dashboardApiName) {
+    if (!dashboardLabel) {
+      throw new Error("dashboardApiName or dashboardLabel is required");
+    }
+    dashboardApiName = lookupApiNameByLabel(dashboardLabel);
+  }
+
+  const outDir = path.resolve(process.cwd(), outputDir);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const cmd = [
+    "sf analytics:dashboard:export",
+    `--name ${dashboardApiName}`,
+    `--output-dir ${outDir}`
+  ].join(" ");
+
+  execSync(cmd, { stdio: "inherit" });
+  return cmd;
+}
+
+if (require.main === module) {
+  let apiName;
+  let label;
+  let dir = "tmp";
+  process.argv.forEach((arg) => {
+    if (arg.startsWith("--dashboard-api-name=")) {
+      apiName = arg.split("=")[1];
+    } else if (arg.startsWith("--dashboard-label=")) {
+      label = arg.split("=")[1];
+    } else if (arg.startsWith("--output-dir=")) {
+      dir = arg.split("=")[1];
+    }
+  });
+  retrieveDashboard({
+    dashboardApiName: apiName,
+    dashboardLabel: label,
+    outputDir: dir
+  });
+}
+
+module.exports = retrieveDashboard;

--- a/test/dashboardRetriever.test.js
+++ b/test/dashboardRetriever.test.js
@@ -1,0 +1,49 @@
+const fs = require("fs");
+const path = require("path");
+jest.mock("child_process", () => ({ execSync: jest.fn() }));
+const { execSync } = require("child_process");
+
+const retrieve = require("../scripts/agents/dashboardRetriever");
+
+describe("dashboardRetriever", () => {
+  const tempDir = path.join(__dirname, "tmp-output");
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true });
+    }
+    Object.assign(process.env, originalEnv);
+  });
+
+  test("builds correct CLI command and creates directory", () => {
+    retrieve({ dashboardApiName: "CR-02", outputDir: tempDir });
+    const expectedCmd = `sf analytics:dashboard:export --name CR-02 --output-dir ${path.resolve(tempDir)}`;
+    expect(execSync).toHaveBeenCalledWith(expectedCmd, { stdio: "inherit" });
+    expect(fs.existsSync(tempDir)).toBe(true);
+  });
+
+  test("looks up API name using label", () => {
+    process.env.SF_ACCESS_TOKEN = "token";
+    process.env.SF_INSTANCE_URL = "https://example.my.salesforce.com";
+    execSync.mockReturnValueOnce(
+      JSON.stringify({ dashboards: [{ label: "My Dash", name: "MY_DASH" }] })
+    );
+    retrieve({ dashboardLabel: "My Dash", outputDir: tempDir });
+    const curlCmd =
+      'curl -s -H "Authorization: Bearer token" https://example.my.salesforce.com/services/data/v59.0/wave/dashboards';
+    const exportCmd = `sf analytics:dashboard:export --name MY_DASH --output-dir ${path.resolve(tempDir)}`;
+    expect(execSync).toHaveBeenNthCalledWith(1, curlCmd, { encoding: "utf8" });
+    expect(execSync).toHaveBeenNthCalledWith(2, exportCmd, {
+      stdio: "inherit"
+    });
+  });
+
+  test("throws when required args are missing", () => {
+    expect(() => retrieve({})).toThrow(
+      "dashboardApiName or dashboardLabel is required"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- enhance `dashboardRetriever` to resolve API name via REST API when given a dashboard label
- update agent documentation and system docs
- expand Jest tests for API name lookup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684afad8febc8327942aaaa719cba4e6