### PR TITLE
Implement dashboardReader agent with tests

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -60,6 +60,7 @@ The project follows the Salesforce DX structure with source located under `force
 - **Salesforce LWC**: Standard library for creating Lightning Web Components.
 - **sfdcAuthorizer**: Node script that performs JWT-based authentication so other automation agents can access the org.
 - **dashboardRetriever**: Downloads dashboard state JSON via the Salesforce CLI so parsing agents can generate `charts.json`. When a dashboard label is supplied, it queries the CRM Analytics REST API to determine the API name before export.
+- **dashboardReader**: Parses exported dashboard JSON into normalized chart definitions written to `charts.json`.
 
 ## Testing
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -13,15 +13,18 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - A `dashboardRetriever` script shall export dashboard state JSON using the Salesforce CLI.
    - If only a dashboard label is provided, the script shall query the CRM Analytics REST API using `SF_INSTANCE_URL` and `SF_ACCESS_TOKEN` environment variables to resolve the dashboard's API name.
    - Retrieved files shall be written to a configurable output directory (default `tmp`).
-3. **Filter Options**
+3. **Dashboard Parsing**
+   - A `dashboardReader` script shall convert exported dashboard JSON into normalized chart definitions.
+   - Parsed charts shall be written to `charts.json`, replacing previous definitions.
+4. **Filter Options**
    - Users shall filter chart results by `host`, `nation`, `season`, and `ski` attributes.
    - Dual list boxes shall be provided for `host`, `nation`, and `season` selections.
    - A combo box shall be provided for the `ski` selection with the choices **All**, **Yes**, and **No**.
    - Selecting a value in any filter shall refresh the remaining filter options so that only valid values are displayed.
-4. **Dynamic Query Generation**
+5. **Dynamic Query Generation**
    - The component shall build a SAQL query based on selected filter values.
    - Filters shall be combined using the `filter q by` SAQL syntax.
-5. **Chart Rendering**
+6. **Chart Rendering**
    - The system shall load the ApexCharts library from a static resource only once during component initialization.
    - All charts shall be shown in pairs side-by-side:
      - The original chart bound to the filters so that it is applying a positive filter
@@ -31,12 +34,12 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - For every chart ID listed in `charts.json`, the markup shall include a pair of containers: one with the ID itself and a second with the `AO` suffix.
    - The component currently displays three chart pairs: `ClimbsByNation`/`ClimbsByNationAO`, `TimeByPeak`/`TimeByPeakAO`, and `CampsByPeak`/`CampsByPeakAO`.
    - Charts configured with a `shadow` effect shall display drop shadows using the ApexCharts `chart.dropShadow` option.
-6. **User Interface**
+7. **User Interface**
    - The component shall expose a Lightning App Page, Record Page, and Home Page target as defined in the metadata file.
    - Chart content shall appear within `<lightning-card>` containers that include `<div>` elements with classes matching the titles of charts within CRM Analytics dashboards.
-7. **Compatibility**
+8. **Compatibility**
    - The application shall be compatible with Salesforce API version 59.0 as specified in the `sfdx-project.json` configuration.
-8. **Change Request Generation**
+9. **Change Request Generation**
    - The system shall compare `charts.json` with `revEngCharts.json` and output `changeRequests.json` listing required code updates.
    - A script shall convert `changeRequests.json` into a human-readable `changeRequestInstructions.txt` file for developers, translating style changes into their corresponding ApexCharts option paths.
 

--- a/scripts/agents/dashboardReader.js
+++ b/scripts/agents/dashboardReader.js
@@ -1,0 +1,119 @@
+// scripts/agents/dashboardReader.js
+// Parses dashboard JSON into normalized chart definitions and writes charts.json
+
+const fs = require('fs');
+const path = require('path');
+
+const COLOR_MAP = {
+  'red': '#EF6B4D',
+  'light blue': '#97C1DA',
+  'blue': '#3C5B81',
+  'green': '#1BAA96',
+  'teal': '#E2F4F9',
+  'grey': '#98ACBD',
+  'dark green': '#175F68',
+  'dark grey': '#283140',
+  'dark blue': '#002060'
+};
+
+function toKebab(str) {
+  return str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+}
+
+function parseSubtitle(subtitle) {
+  const meta = {};
+  if (!subtitle) return meta;
+  subtitle.split(';').forEach((pair) => {
+    const [key, value] = pair.split('=').map((s) => s.trim());
+    if (key) meta[key] = value;
+  });
+  return meta;
+}
+
+function mapColors(str) {
+  if (!str) return str;
+  return str
+    .split(',')
+    .map((c) => COLOR_MAP[c.trim().toLowerCase()] || c.trim())
+    .join(',');
+}
+
+function readDashboard({
+  dashboardApiName,
+  inputDir = 'tmp',
+  chartsFile = 'charts.json',
+  silent = false
+}) {
+  if (!dashboardApiName) {
+    throw new Error('dashboardApiName is required');
+  }
+
+  const filePath = path.resolve(inputDir, `${dashboardApiName}.json`);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Dashboard JSON not found: ${filePath}`);
+  }
+
+  const dashboard = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const widgets = dashboard.widgets || [];
+  const charts = [];
+
+  widgets.forEach((w) => {
+    const title = w.title || (w.properties && w.properties.title);
+    const saql = w.saql || (w.step && w.step.query);
+    if (!title || !saql) return; // skip invalid widget
+
+    const meta = parseSubtitle(w.subtitle);
+    const type = meta.type || w.type;
+    if (!type) return;
+
+    const style = {};
+    if (meta.colors) style.seriesColors = mapColors(meta.colors);
+    if (meta.font) style.font = meta.font;
+    if (meta.shadow === 'true' || meta.effects === 'shadow') {
+      style.effects = ['shadow'];
+    }
+
+    const chart = {
+      dashboard: dashboardApiName,
+      id: toKebab(title),
+      type,
+      title: meta.title || title,
+      fieldMappings: w.fieldMappings || {},
+      saql,
+      style
+    };
+
+    charts.push(chart);
+  });
+
+  const output = { charts };
+  fs.writeFileSync(chartsFile, JSON.stringify(output, null, 2));
+  if (!silent) {
+    console.log(`Wrote ${charts.length} charts to ${chartsFile}`);
+  }
+  return output;
+}
+
+if (require.main === module) {
+  const opts = {};
+  process.argv.slice(2).forEach((arg) => {
+    if (arg.startsWith('--dashboard-api-name=')) {
+      opts.dashboardApiName = arg.split('=')[1];
+    } else if (arg.startsWith('--input-dir=')) {
+      opts.inputDir = arg.split('=')[1];
+    } else if (arg.startsWith('--charts-file=')) {
+      opts.chartsFile = arg.split('=')[1];
+    } else if (arg === '--silent') {
+      opts.silent = true;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log('Usage: node dashboardReader.js --dashboard-api-name <name> [--input-dir dir] [--charts-file file] [--silent]');
+      process.exit(0);
+    }
+  });
+  readDashboard(opts);
+}
+
+module.exports = readDashboard;

--- a/test/dashboardReader.test.js
+++ b/test/dashboardReader.test.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const readDashboard = require('../scripts/agents/dashboardReader');
+
+describe('dashboardReader', () => {
+  const tmpDir = path.join(__dirname, 'dash');
+  const chartsFile = path.join(tmpDir, 'charts.json');
+  const inputFile = path.join(tmpDir, 'CR-02.json');
+
+  beforeEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  test('parses widgets and writes charts.json', () => {
+    const dashboard = {
+      widgets: [
+        {
+          title: 'Climbs By Nation',
+          saql: 'q = load "d";',
+          subtitle: 'type=bar; colors=red; title=Top 20 Climbs by Nation',
+          fieldMappings: { nation: 'Nation', Climbs: 'Climbs' }
+        },
+        {
+          title: 'Time By Peak',
+          step: { query: 'saql2' },
+          subtitle:
+            'type=box-and-whisker; colors=light blue,dark blue; title=Days per Peak by Top 20 Climbs',
+          fieldMappings: {
+            peakid: 'Peak ID',
+            A: 'Min',
+            B: 'Q1',
+            C: 'Q3',
+            D: 'Max'
+          }
+        },
+        { saql: 'invalid' }
+      ]
+    };
+    fs.writeFileSync(inputFile, JSON.stringify(dashboard));
+
+    const result = readDashboard({
+      dashboardApiName: 'CR-02',
+      inputDir: tmpDir,
+      chartsFile
+    });
+
+    const data = JSON.parse(fs.readFileSync(chartsFile, 'utf8'));
+    expect(data).toEqual(result);
+    expect(data.charts.length).toBe(2);
+    const ids = data.charts.map((c) => c.id);
+    expect(ids).toEqual(['climbs-by-nation', 'time-by-peak']);
+    expect(data.charts[0].style.seriesColors).toBe('#EF6B4D');
+    expect(data.charts[1].style.seriesColors).toBe('#97C1DA,#002060');
+  });
+
+  test('throws when file missing', () => {
+    expect(() =>
+      readDashboard({ dashboardApiName: 'CR-02', inputDir: tmpDir, chartsFile })
+    ).toThrow(/Dashboard JSON not found/);
+  });
+
+  test('throws when dashboardApiName missing', () => {
+    expect(() => readDashboard({ inputDir: tmpDir, chartsFile })).toThrow(
+      /dashboardApiName is required/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add dashboardReader agent
- test dashboardReader agent functionality
- document dashboardReader in SystemDesign and SystemRequirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b04a9280c8327bbd8f145952eab34