### PR TITLE
Handle analytics query limit

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -52,6 +52,7 @@ The project follows the Salesforce DX structure with source located under `force
 4. `executeQuery` runs SAQL queries for all charts using the selected filters.
 5. The first bar chart uses the filters as selected; the second applies the inverse of the `host` and `nation` filters.
 6. Updating filters triggers `filtersUpdated`, which refreshes every chart with new query data.
+7. Chart data queries are executed sequentially to honor the CRM Analytics limit of five concurrent queries.
 
 ## Dependencies
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -49,6 +49,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
 
 1. **Performance**
    - Chart rendering shall occur within one second after the ApexCharts library loads and the SAQL query completes.
+   - No more than five CRM Analytics queries shall execute concurrently. Chart queries must run sequentially to comply with this limit.
 2. **Security**
    - The LWC shall operate with sharing enforced through Salesforce security mechanisms.
    - A Node script named `sfdcAuthorizer` shall authenticate to Salesforce via JWT and set the default CLI username for deployment and testing automation.

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
@@ -224,7 +224,6 @@ export default class SacCharts extends LightningElement {
     return { query: saql };
   }
 
-  @wire(executeQuery, { query: "$climbsByNationQuery" })
   onClimbsByNation({ data }) {
     if (data) {
       const labels = [],
@@ -242,7 +241,6 @@ export default class SacCharts extends LightningElement {
     }
   }
 
-  @wire(executeQuery, { query: "$climbsByNationAOQuery" })
   onClimbsByNationAO({ data }) {
     if (data) {
       const labels = [],
@@ -260,7 +258,6 @@ export default class SacCharts extends LightningElement {
     }
   }
 
-  @wire(executeQuery, { query: "$timeByPeakQuery" })
   onTimeByPeak({ data }) {
     if (data) {
       const records = data.results.records.map((r) => ({
@@ -275,7 +272,6 @@ export default class SacCharts extends LightningElement {
     }
   }
 
-  @wire(executeQuery, { query: "$timeByPeakAOQuery" })
   onTimeByPeakAO({ data }) {
     if (data) {
       const records = data.results.records.map((r) => ({
@@ -290,7 +286,6 @@ export default class SacCharts extends LightningElement {
     }
   }
 
-  @wire(executeQuery, { query: "$campsByPeakQuery" })
   onCampsByPeak({ data }) {
     if (data) {
       const labels = [],
@@ -308,7 +303,6 @@ export default class SacCharts extends LightningElement {
     }
   }
 
-  @wire(executeQuery, { query: "$campsByPeakAOQuery" })
   onCampsByPeakAO({ data }) {
     if (data) {
       const labels = [],
@@ -392,14 +386,26 @@ export default class SacCharts extends LightningElement {
   handleSkiChange(event) {
     this.skiSelection = event.detail.value;
   }
-  filtersUpdated() {
-    // manually trigger the wires to rerun
-    this.onClimbsByNation({ data: undefined });
-    this.onClimbsByNationAO({ data: undefined });
-    this.onTimeByPeak({ data: undefined });
-    this.onTimeByPeakAO({ data: undefined });
-    this.onCampsByPeak({ data: undefined });
-    this.onCampsByPeakAO({ data: undefined });
+  async filtersUpdated() {
+    await this.runChartQueries();
+  }
+
+  @api
+  async runChartQueries() {
+    const pairs = [
+      [this.climbsByNationQuery, this.onClimbsByNation.bind(this)],
+      [this.climbsByNationAOQuery, this.onClimbsByNationAO.bind(this)],
+      [this.timeByPeakQuery, this.onTimeByPeak.bind(this)],
+      [this.timeByPeakAOQuery, this.onTimeByPeakAO.bind(this)],
+      [this.campsByPeakQuery, this.onCampsByPeak.bind(this)],
+      [this.campsByPeakAOQuery, this.onCampsByPeakAO.bind(this)]
+    ];
+    for (const [query, handler] of pairs) {
+      if (query) {
+        const data = await executeQuery(query);
+        handler({ data });
+      }
+    }
   }
 
   // ---- SAQL filter builder ----


### PR DESCRIPTION
## Summary
- queue chart queries to avoid exceeding analytics query limits
- document sequential query execution
- specify performance requirement on concurrent queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b1380bd4883278b59e49a86561a5b