### PR TITLE
Update docs for Render button-driven refresh

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -51,7 +51,7 @@ The project follows the Salesforce DX structure with source located under `force
 3. Option queries apply the currently selected filters (excluding the field being queried) so that each filter only displays valid values.
 4. `executeQuery` runs SAQL queries for all charts using the selected filters.
 5. The first bar chart uses the filters as selected; the second applies the inverse of the `host` and `nation` filters.
-6. Updating filters triggers `filtersUpdated`, which refreshes every chart with new query data.
+6. The **Render** button triggers `filtersUpdated`, which refreshes every chart with new query data.
 7. Chart data queries are executed sequentially to honor the CRM Analytics limit of five concurrent queries.
 
 ## Dependencies

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -31,7 +31,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - All charts shall be shown in pairs side-by-side:
      - The original chart bound to the filters so that it is applying a positive filter
      - A clone of the original chart with `AO` appended to the ID which shows 'All Others' or the inverse (!=) of the filters applied
-   - Chart data shall refresh whenever the user updates filter selections
+   - Chart data shall refresh only when the user clicks the **Render** button
    - Chart content and presentation shall be governed by CRMA dashboards referenced by a property in `charts.json`.
    - For every chart ID listed in `charts.json`, the markup shall include a pair of containers: one with the ID itself and a second with the `AO` suffix.
    - The component currently displays three chart pairs: `ClimbsByNation`/`ClimbsByNationAO`, `TimeByPeak`/`TimeByPeakAO`, and `CampsByPeak`/`CampsByPeakAO`.


### PR DESCRIPTION
## Summary
- clarify that charts refresh only after clicking the Render button in docs
- update System Design to note Render button triggers refresh

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_684b37de331883278aabf6bd6386a801