### PR TITLE
Add chart page navigation

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -36,7 +36,7 @@ The project follows the Salesforce DX structure with source located under `force
 
 - **dynamicCharts.js**: Core logic for loading datasets, handling filter selections, generating SAQL, cross-filtering available options, and rendering six charts with ApexCharts.
 - The component applies visual effects such as drop shadows based on chart settings to enhance chart readability.
-- **dynamicCharts.html**: Presents filter controls and six chart containers arranged in multiple cards.
+- **dynamicCharts.html**: Presents filter controls and a left-hand list of chart names. Each chart pair appears on its own page that can be selected from this list.
 - **dynamicCharts.js-meta.xml**: Exposes the component to App, Record, and Home pages.
 - **DPOStateMachine.cls**: Placeholder Apex class reserved for future enhancements or server-side processing.
 - **charts.json**: Generated from the CRM Analytics dashboards to list supported charts. Primary charts are included, while `AO` variants are ignored.
@@ -48,11 +48,12 @@ The project follows the Salesforce DX structure with source located under `force
 
 1. `getDatasets` retrieves dataset IDs when the component initializes.
 2. Dual list boxes and combo box capture filter selections from the user.
-3. Option queries apply the currently selected filters (excluding the field being queried) so that each filter only displays valid values.
-4. A dynamically imported `executeQuery` runs SAQL queries for all charts using the selected filters.
-5. The first bar chart uses the filters as selected; the second applies the inverse of the `host` and `nation` filters.
-6. The **Render** button triggers `filtersUpdated`, which refreshes every chart with new query data.
-7. Chart data queries are executed sequentially to honor the CRM Analytics limit of five concurrent queries. The module is loaded at runtime so the ESLint wire adapter rules do not apply.
+3. A left-hand navigation list allows the user to switch between chart pages.
+4. Option queries apply the currently selected filters (excluding the field being queried) so that each filter only displays valid values.
+5. A dynamically imported `executeQuery` runs SAQL queries for all charts using the selected filters.
+6. The first bar chart uses the filters as selected; the second applies the inverse of the `host` and `nation` filters.
+7. The **Render** button triggers `filtersUpdated`, which refreshes every chart with new query data.
+8. Chart data queries are executed sequentially to honor the CRM Analytics limit of five concurrent queries. The module is loaded at runtime so the ESLint wire adapter rules do not apply.
 
 ## Dependencies
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -39,11 +39,13 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
 8. **User Interface**
    - The component shall expose a Lightning App Page, Record Page, and Home Page target as defined in the metadata file.
    - Chart content shall appear within `<lightning-card>` containers that include `<div>` elements with classes matching the titles of charts within CRM Analytics dashboards.
+   - A vertical unordered list on the left shall allow users to select which chart page is displayed. Each chart pair occupies its own page.
 9. **Compatibility**
    - The application shall be compatible with Salesforce API version 59.0 as specified in the `sfdx-project.json` configuration.
 10. **Change Request Generation**
-   - A Node script named `changeRequestGenerator` shall compare `charts.json` with `revEngCharts.json` and output `changeRequests.json` listing required code updates.
-   - A follow-on script shall convert `changeRequests.json` into a human-readable `changeRequestInstructions.txt` file for developers, translating style changes into their corresponding ApexCharts option paths.
+
+- A Node script named `changeRequestGenerator` shall compare `charts.json` with `revEngCharts.json` and output `changeRequests.json` listing required code updates.
+- A follow-on script shall convert `changeRequests.json` into a human-readable `changeRequestInstructions.txt` file for developers, translating style changes into their corresponding ApexCharts option paths.
 
 ## Non‑Functional Requirements
 

--- a/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
+++ b/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
@@ -49,6 +49,34 @@ describe("c-dynamic-charts", () => {
     expect(chart7).not.toBeNull();
   });
 
+  it("shows ClimbsByNation page by default", () => {
+    const element = createElement("c-dynamic-charts", {
+      is: DynamicCharts
+    });
+    document.body.appendChild(element);
+
+    const climbsPage = element.shadowRoot.querySelector(
+      "div[data-page='ClimbsByNation']"
+    );
+    expect(climbsPage.classList).toContain("slds-show");
+  });
+
+  it("switches pages when navigation link clicked", async () => {
+    const element = createElement("c-dynamic-charts", {
+      is: DynamicCharts
+    });
+    document.body.appendChild(element);
+
+    const link = element.shadowRoot.querySelector("a[data-id='TimeByPeak']");
+    link.click();
+    await flushPromises();
+
+    const timePage = element.shadowRoot.querySelector(
+      "div[data-page='TimeByPeak']"
+    );
+    expect(timePage.classList).toContain("slds-show");
+  });
+
   it("initializes ApexCharts instances for all charts", async () => {
     const element = createElement("c-dynamic-charts", {
       is: DynamicCharts

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.html
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.html
@@ -62,46 +62,90 @@
     </table>
   </lightning-card>
 
-  <lightning-card title="Chart Series" icon-name="custom:custom1">
-      <lightning-layout>
-        <lightning-layout-item size="6">
-          <div
-            class="ClimbsByNation slds-var-m-around_medium"
-            lwc:dom="manual"
-          ></div>
-        </lightning-layout-item>
-        <lightning-layout-item size="6">
-          <div
-            class="ClimbsByNationAO slds-var-m-around_medium"
-            lwc:dom="manual"
-          ></div>
-        </lightning-layout-item>
-        <lightning-layout-item size="6">
-          <div
-            class="CampsByPeak slds-var-m-around_medium"
-            lwc:dom="manual"
-          ></div>
-        </lightning-layout-item>
-        <lightning-layout-item size="6">
-          <div
-            class="CampsByPeakAO slds-var-m-around_medium"
-            lwc:dom="manual"
-          ></div>
-        </lightning-layout-item>
-      </lightning-layout>
-    </lightning-card>
-
-  <lightning-card title="Box Plot Series" icon-name="custom:custom2">
-    <lightning-layout>
-      <lightning-layout-item size="6">
-        <div class="TimeByPeak slds-var-m-around_medium" lwc:dom="manual"></div>
-      </lightning-layout-item>
-      <lightning-layout-item size="6">
-        <div
-          class="TimeByPeakAO slds-var-m-around_medium"
-          lwc:dom="manual"
-        ></div>
-      </lightning-layout-item>
-    </lightning-layout>
-  </lightning-card>
+  <lightning-layout>
+    <lightning-layout-item size="2">
+      <ul class="slds-list_dotted">
+        <li>
+          <a
+            href="javascript:void(0);"
+            data-id="ClimbsByNation"
+            onclick={handleNavClick}
+            >ClimbsByNation</a
+          >
+        </li>
+        <li>
+          <a
+            href="javascript:void(0);"
+            data-id="CampsByPeak"
+            onclick={handleNavClick}
+            >CampsByPeak</a
+          >
+        </li>
+        <li>
+          <a
+            href="javascript:void(0);"
+            data-id="TimeByPeak"
+            onclick={handleNavClick}
+            >TimeByPeak</a
+          >
+        </li>
+      </ul>
+    </lightning-layout-item>
+    <lightning-layout-item size="10">
+      <div class={climbsPageClass} data-page="ClimbsByNation">
+        <lightning-card title="Chart Series" icon-name="custom:custom1">
+          <lightning-layout>
+            <lightning-layout-item size="6">
+              <div
+                class="ClimbsByNation slds-var-m-around_medium"
+                lwc:dom="manual"
+              ></div>
+            </lightning-layout-item>
+            <lightning-layout-item size="6">
+              <div
+                class="ClimbsByNationAO slds-var-m-around_medium"
+                lwc:dom="manual"
+              ></div>
+            </lightning-layout-item>
+          </lightning-layout>
+        </lightning-card>
+      </div>
+      <div class={campsPageClass} data-page="CampsByPeak">
+        <lightning-card title="Chart Series" icon-name="custom:custom1">
+          <lightning-layout>
+            <lightning-layout-item size="6">
+              <div
+                class="CampsByPeak slds-var-m-around_medium"
+                lwc:dom="manual"
+              ></div>
+            </lightning-layout-item>
+            <lightning-layout-item size="6">
+              <div
+                class="CampsByPeakAO slds-var-m-around_medium"
+                lwc:dom="manual"
+              ></div>
+            </lightning-layout-item>
+          </lightning-layout>
+        </lightning-card>
+      </div>
+      <div class={timePageClass} data-page="TimeByPeak">
+        <lightning-card title="Box Plot Series" icon-name="custom:custom2">
+          <lightning-layout>
+            <lightning-layout-item size="6">
+              <div
+                class="TimeByPeak slds-var-m-around_medium"
+                lwc:dom="manual"
+              ></div>
+            </lightning-layout-item>
+            <lightning-layout-item size="6">
+              <div
+                class="TimeByPeakAO slds-var-m-around_medium"
+                lwc:dom="manual"
+              ></div>
+            </lightning-layout-item>
+          </lightning-layout>
+        </lightning-card>
+      </div>
+    </lightning-layout-item>
+  </lightning-layout>
 </template>

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
@@ -1,5 +1,8 @@
 import { LightningElement, wire, api } from "lwc";
-import { getDatasets, executeQuery as wiredExecuteQuery } from "lightning/analyticsWaveApi";
+import {
+  getDatasets,
+  executeQuery as wiredExecuteQuery
+} from "lightning/analyticsWaveApi";
 import apexchartJs from "@salesforce/resourceUrl/ApexCharts";
 import { loadScript } from "lightning/platformResourceLoader";
 
@@ -24,6 +27,18 @@ export default class SacCharts extends LightningElement {
 
   chartObject = {};
   _chartsInitialized = false;
+
+  activePage = "ClimbsByNation";
+
+  get climbsPageClass() {
+    return this.activePage === "ClimbsByNation" ? "slds-show" : "slds-hide";
+  }
+  get campsPageClass() {
+    return this.activePage === "CampsByPeak" ? "slds-show" : "slds-hide";
+  }
+  get timePageClass() {
+    return this.activePage === "TimeByPeak" ? "slds-show" : "slds-hide";
+  }
 
   chartSettings = {
     ClimbsByNation: {
@@ -385,6 +400,13 @@ export default class SacCharts extends LightningElement {
   }
   handleSkiChange(event) {
     this.skiSelection = event.detail.value;
+  }
+  handleNavClick(event) {
+    event.preventDefault();
+    const id = event.target.dataset.id;
+    if (id) {
+      this.activePage = id;
+    }
   }
   async filtersUpdated() {
     await this.runChartQueries();


### PR DESCRIPTION
## Summary
- add left-side navigation menu to switch between chart pages
- update chart component to show one pair of charts at a time
- document page navigation in design and requirements
- test navigation behaviour

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_684b6b70dbc08327949e94a3c1fe593b