### PR TITLE
Implement queued query handling

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -50,10 +50,10 @@ The project follows the Salesforce DX structure with source located under `force
 2. Dual list boxes and combo box capture filter selections from the user.
 3. A left-hand navigation list allows the user to switch between chart pages.
 4. Option queries apply the currently selected filters (excluding the field being queried) so that each filter only displays valid values.
-5. A dynamically imported `executeQuery` runs SAQL queries for all charts using the selected filters.
+5. Chart queries are placed into a queue and executed via a single `executeQuery` wire adapter using the `nextQuery` getter.
 6. The first bar chart uses the filters as selected; the second applies the inverse of the `host` and `nation` filters.
 7. The **Render** button triggers `filtersUpdated`, which refreshes every chart with new query data.
-8. Chart data queries are executed sequentially to honor the CRM Analytics limit of five concurrent queries. The module is loaded at runtime so the ESLint wire adapter rules do not apply.
+8. The queue ensures no more than one CRM Analytics query runs at a time so the five-concurrent limit is never exceeded.
 
 ## Dependencies
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -51,7 +51,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
 
 1. **Performance**
    - Chart rendering shall occur within one second after the ApexCharts library loads and the SAQL query completes.
-   - No more than five CRM Analytics queries shall execute concurrently. Chart queries must run sequentially to comply with this limit.
+   - No more than five CRM Analytics queries shall execute concurrently. A query queue processes one request at a time to comply with this limit.
 2. **Security**
    - The LWC shall operate with sharing enforced through Salesforce security mechanisms.
    - A Node script named `sfdcAuthorizer` shall authenticate to Salesforce via JWT and set the default CLI username for deployment and testing automation.


### PR DESCRIPTION
## Summary
- queue chart queries in dynamicCharts.js so executeQuery uses wire adapter
- document the query queue design and requirement updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bf1c98b9483279b9188f0b15c648e