### PR TITLE
Implement lwcTester agent

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -72,6 +72,7 @@ The project follows the Salesforce DX structure with source located under `force
 
 Unit tests reside under `force-app/main/default/lwc/dynamicCharts/__tests__` and use `sfdx-lwc-jest`. Additional Apex test classes are stored in the `force-app/test` package to validate server-side code. The root `test` directory contains integration checks—for example, verifying that chart container IDs (and their `AO` counterparts) match the chart definitions in `charts.json`.
 The suite also verifies that each chart container creates an ApexCharts instance by mocking `lightning/platformResourceLoader` to load the real library.
+Test execution is orchestrated by the `lwcTester` agent which installs required dev dependencies, scaffolds `test/lwcTester`, and runs Jest with coverage thresholds prior to deployment.
 
 ## Future Considerations
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -62,6 +62,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - The system should allow additional chart types and datasets to be introduced with minimal code changes.
 5. **Testing**
    - Automated tests shall verify that each chart container successfully initializes an ApexCharts instance.
+   - A Node script named `lwcTester` shall run Jest unit and integration tests from `test/lwcTester` and enforce minimum coverage of 80% statements, 75% branches, 80% functions, and 80% lines before deployment.
 
 ## Out of Scope
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "description": "Salesforce App",
   "scripts": {
     "lint": "eslint **/{aura,lwc}/**/*.js",
-    "test": "npm run test:unit",
+    "test": "npm run test:lwc:unit",
+    "test:lwc:unit": "sfdx-lwc-jest --coverage",
+    "test:lwc:integration": "sfdx-lwc-jest --coverage test/lwcTester/integration",
+    "test:lwc:ci": "npm run lint && npm run test:lwc:unit",
     "test:unit": "sfdx-lwc-jest",
     "test:unit:watch": "sfdx-lwc-jest --watch",
     "test:unit:debug": "sfdx-lwc-jest --debug",

--- a/scripts/agents/lwcTester.js
+++ b/scripts/agents/lwcTester.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const authorize = require('./sfdcAuthorizer');
+
+function ensureDevDependencies() {
+  const pkgPath = path.resolve(process.cwd(), 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const devDeps = pkg.devDependencies || {};
+  const needed = ['sfdx-lwc-jest', 'apexcharts', 'jest-canvas-mock'];
+  const missing = needed.filter((d) => !devDeps[d]);
+  if (missing.length) {
+    const cmd = `npm install --save-dev ${missing.join(' ')}`;
+    execSync(cmd, { stdio: 'inherit' });
+  }
+}
+
+function ensureTestStructure(baseDir = 'test/lwcTester') {
+  ['unit', 'integration', '__mocks__', 'reports'].forEach((d) => {
+    fs.mkdirSync(path.join(baseDir, d), { recursive: true });
+  });
+}
+
+function runTests({ unit, integration, ci } = {}) {
+  let script = 'npm run test:lwc:unit';
+  if (integration) script = 'npm run test:lwc:integration';
+  if (ci) {
+    execSync('npm run lint', { stdio: 'inherit' });
+  }
+  execSync(script, { stdio: 'inherit' });
+}
+
+function lwcTester(opts = {}) {
+  authorize();
+  ensureDevDependencies();
+  ensureTestStructure();
+  runTests(opts);
+}
+
+if (require.main === module) {
+  const opts = {};
+  process.argv.slice(2).forEach((arg) => {
+    if (arg === '--unit' || arg === '-u') opts.unit = true;
+    else if (arg === '--integration' || arg === '-i') opts.integration = true;
+    else if (arg === '--ci' || arg === '-c') opts.ci = true;
+  });
+  lwcTester(opts);
+}
+
+module.exports = lwcTester;
+module.exports.ensureTestStructure = ensureTestStructure;
+module.exports.runTests = runTests;

--- a/test/lwcTester.test.js
+++ b/test/lwcTester.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+jest.mock('child_process', () => ({ execSync: jest.fn() }));
+const { execSync } = require('child_process');
+
+const tester = require('../scripts/agents/lwcTester');
+
+describe('lwcTester', () => {
+  const baseDir = path.join(__dirname, 'lwcTester');
+
+  beforeEach(() => {
+    fs.rmSync(baseDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  test('creates test folder structure', () => {
+    tester.ensureTestStructure(baseDir);
+    expect(fs.existsSync(path.join(baseDir, 'unit'))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, 'integration'))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, '__mocks__'))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, 'reports'))).toBe(true);
+  });
+
+  test('runs unit tests by default', () => {
+    tester.runTests();
+    expect(execSync).toHaveBeenCalledWith('npm run test:lwc:unit', { stdio: 'inherit' });
+  });
+
+  test('runs integration tests when flag provided', () => {
+    tester.runTests({ integration: true });
+    expect(execSync).toHaveBeenCalledWith('npm run test:lwc:integration', { stdio: 'inherit' });
+  });
+
+  test('runs lint in ci mode', () => {
+    tester.runTests({ ci: true });
+    expect(execSync).toHaveBeenNthCalledWith(1, 'npm run lint', { stdio: 'inherit' });
+    expect(execSync).toHaveBeenNthCalledWith(2, 'npm run test:lwc:unit', { stdio: 'inherit' });
+  });
+});


### PR DESCRIPTION
## Summary
- create `lwcTester` agent with directory scaffolding and jest execution
- support new test scripts in `package.json`
- document automated test runner in design and requirements
- add Jest tests for lwcTester

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bf826a8f483278bbf39d1f8a23264