### PR TITLE
Add sfdcDeployer agent

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -67,6 +67,7 @@ The project follows the Salesforce DX structure with source located under `force
 - **lwcReader**: Creates Lightning Web Component scaffolding from `charts.json` and writes the files under `force-app/main/default/lwc`.
 - **changeRequestGenerator**: Compares `charts.json` with `revEngCharts.json` to produce `changeRequests.json` for synchronizing the component source.
 - **syncCharts**: Reads `changeRequests.json` and updates the `dynamicCharts` LWC by modifying the HTML and JS files via AST transforms.
+- **sfdcDeployer**: Deploys metadata in `force-app/main/default` to the target org using the `sf` CLI and writes a JSON report under `reports/`.
 
 ## Testing
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -62,7 +62,8 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - The system should allow additional chart types and datasets to be introduced with minimal code changes.
 5. **Testing**
    - Automated tests shall verify that each chart container successfully initializes an ApexCharts instance.
-   - A Node script named `lwcTester` shall run Jest unit and integration tests from `test/lwcTester` and enforce minimum coverage of 80% statements, 75% branches, 80% functions, and 80% lines before deployment.
+- A Node script named `lwcTester` shall run Jest unit and integration tests from `test/lwcTester` and enforce minimum coverage of 80% statements, 75% branches, 80% functions, and 80% lines before deployment.
+- A Node script named `sfdcDeployer` shall deploy metadata using the `sf` CLI and write a deployment report under `reports`.
 
 ## Out of Scope
 

--- a/scripts/agents/sfdcDeployer.js
+++ b/scripts/agents/sfdcDeployer.js
@@ -1,0 +1,61 @@
+// scripts/agents/sfdcDeployer.js
+// Deploys metadata to a Salesforce org using the `sf` CLI
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const authorize = require('./sfdcAuthorizer');
+
+function writeReport(content) {
+  const reportsDir = path.resolve('reports');
+  fs.mkdirSync(reportsDir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const file = path.join(reportsDir, `deploy-report-${timestamp}.json`);
+  fs.writeFileSync(file, content);
+  console.log(`Deployment report written to ${file}`);
+  return file;
+}
+
+function sfdcDeployer({
+  sourceDir = 'force-app/main/default',
+  checkOnly = false,
+  verbose = false,
+  wait = 10
+} = {}) {
+  authorize();
+
+  const baseCmd = checkOnly
+    ? 'sf project deploy validate'
+    : 'sf project deploy start';
+
+  const args = [
+    `--source-dir ${path.resolve(sourceDir)}`,
+    `--wait ${wait}`,
+    '--json'
+  ];
+  if (verbose) args.push('--verbose');
+
+  const cmd = `${baseCmd} ${args.join(' ')}`;
+  const output = execSync(cmd, { encoding: 'utf8' });
+  const reportPath = writeReport(output);
+  return { cmd, reportPath };
+}
+
+if (require.main === module) {
+  const opts = {};
+  process.argv.slice(2).forEach((arg) => {
+    if (arg.startsWith('--source-dir=')) {
+      opts.sourceDir = arg.split('=')[1];
+    } else if (arg === '--checkonly' || arg === '-c') {
+      opts.checkOnly = true;
+    } else if (arg === '--verbose' || arg === '-v') {
+      opts.verbose = true;
+    } else if (arg.startsWith('--wait=')) {
+      opts.wait = parseInt(arg.split('=')[1], 10);
+    }
+  });
+  sfdcDeployer(opts);
+}
+
+module.exports = sfdcDeployer;
+module.exports.writeReport = writeReport;

--- a/test/sfdcDeployer.test.js
+++ b/test/sfdcDeployer.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+jest.mock('child_process', () => ({ execSync: jest.fn() }));
+jest.mock('../scripts/agents/sfdcAuthorizer', () => jest.fn());
+
+const { execSync } = require('child_process');
+const deployer = require('../scripts/agents/sfdcDeployer');
+
+describe('sfdcDeployer', () => {
+  const reportsDir = path.resolve('reports');
+
+  beforeEach(() => {
+    fs.rmSync(reportsDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  test('builds deploy command and writes report', () => {
+    execSync.mockReturnValueOnce('{"status":"Succeeded"}');
+    const { cmd, reportPath } = deployer({
+      sourceDir: 'src',
+      verbose: true,
+      wait: 5
+    });
+    const expectedCmd = `sf project deploy start --source-dir ${path.resolve('src')} --wait 5 --json --verbose`;
+    expect(execSync).toHaveBeenCalledWith(expectedCmd, { encoding: 'utf8' });
+    expect(fs.existsSync(reportPath)).toBe(true);
+    expect(cmd).toBe(expectedCmd);
+  });
+
+  test('uses validate when checkonly', () => {
+    execSync.mockReturnValueOnce('{}');
+    const { cmd } = deployer({ checkOnly: true });
+    expect(cmd.startsWith('sf project deploy validate')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `sfdcDeployer` agent using `sf project deploy`
- add unit tests for deployer agent
- document deployer in system design and requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bfbe8ff44832794dd0b477a95dfd3