### PR TITLE
Fix lwcReader agent

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -65,7 +65,7 @@ All automation scripts assume a Node.js 18 runtime. Using older or unsupported v
 - **sfdcAuthorizer**: Node script that performs JWT-based authentication so other automation agents can access the org.
  - **dashboardRetriever**: Downloads dashboard state JSON using the CRM Analytics REST API so parsing agents can generate `charts.json`. When a dashboard label is supplied, it first queries the REST API to determine the API name.
  - **dashboardReader**: Parses exported dashboard JSON into normalized chart definitions written to `charts.json`. The parser now supports dashboard files where the `widgets` section is expressed as an object rather than an array.
-- **lwcReader**: Creates Lightning Web Component scaffolding from `charts.json` and writes the files under `force-app/main/default/lwc`.
+ - **lwcReader**: Parses the existing `dynamicCharts` component to generate `revEngCharts.json` describing the charts currently implemented.
 - **changeRequestGenerator**: Compares `charts.json` with `revEngCharts.json` to produce `changeRequests.json` for synchronizing the component source.
 - **syncCharts**: Reads `changeRequests.json` and updates the `dynamicCharts` LWC by modifying the HTML and JS files via AST transforms.
 - **sfdcDeployer**: Deploys metadata in `force-app/main/default` to the target org using the `sf` CLI and writes a JSON report under `reports/`.

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -17,8 +17,8 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - A `dashboardReader` script shall convert exported dashboard JSON into normalized chart definitions.
    - The parser must handle dashboard files where the `widgets` section is either an array or a keyed object.
    - Parsed charts shall be written to `charts.json`, replacing previous definitions.
-4. **Component Generation**
-   - A `lwcReader` script shall read `charts.json` and generate Lightning Web Component folders under `force-app/main/default/lwc`.
+4. **Component Analysis**
+   - A `lwcReader` script shall parse the existing Lightning Web Component source and output `revEngCharts.json` describing the charts implemented.
 5. **Filter Options**
    - Users shall filter chart results by `host`, `nation`, `season`, and `ski` attributes.
    - Dual list boxes shall be provided for `host`, `nation`, and `season` selections.

--- a/scripts/agents/lwcReader.js
+++ b/scripts/agents/lwcReader.js
@@ -1,80 +1,107 @@
 // scripts/agents/lwcReader.js
-// Generates Lightning Web Component files from chart definitions in charts.json
+// Parses the dynamicCharts LWC to produce revEngCharts.json
 
 const fs = require('fs');
 const path = require('path');
 
-function toKebab(str) {
-  return str
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .replace(/[\s_]+/g, '-')
-    .toLowerCase();
-}
-
-function ensureDir(dir) {
-  fs.mkdirSync(dir, { recursive: true });
-}
-
-function renderTemplates(chart, templateDir) {
-  const templates = {
-    js: `import { LightningElement } from 'lwc';\n\nexport default class ${chart.id} extends LightningElement {\n  chart = ${JSON.stringify(chart, null, 2)};\n}\n`,
-    html: `<template>\n  <div class="chart-${toKebab(chart.id)}"></div>\n</template>\n`,
-    xml: `<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<LightningComponentBundle xmlns=\"http://soap.sforce.com/2006/04/metadata\" fqn=\"${chart.id}\">\n  <apiVersion>59.0</apiVersion>\n  <isExposed>false</isExposed>\n</LightningComponentBundle>\n`
-  };
-
-  if (templateDir) {
-    const jsPath = path.join(templateDir, 'component.js');
-    const htmlPath = path.join(templateDir, 'template.html');
-    const xmlPath = path.join(templateDir, 'meta.xml');
-    if (fs.existsSync(jsPath)) templates.js = fs.readFileSync(jsPath, 'utf8');
-    if (fs.existsSync(htmlPath)) templates.html = fs.readFileSync(htmlPath, 'utf8');
-    if (fs.existsSync(xmlPath)) templates.xml = fs.readFileSync(xmlPath, 'utf8');
-    templates.js = templates.js.replace(/__CLASS__/g, chart.id).replace(/__CHART__/g, JSON.stringify(chart, null, 2));
-    templates.html = templates.html.replace(/__CLASS__/g, toKebab(chart.id));
-    templates.xml = templates.xml.replace(/__CLASS__/g, chart.id);
+function extractChartSettings(jsContent) {
+  const start = jsContent.indexOf('chartSettings = {');
+  if (start === -1) {
+    return {};
   }
-  return templates;
+  const end = jsContent.indexOf('};', start);
+  const objectSource = jsContent.slice(start + 'chartSettings = '.length, end + 1);
+  // eslint-disable-next-line no-new-func
+  return new Function(`return ${objectSource}`)();
 }
 
-function generateLWCs({ chartsFile = 'charts.json', outputDir = 'force-app/main/default/lwc', templateDir }) {
-  if (!fs.existsSync(chartsFile)) {
-    throw new Error(`charts file not found: ${chartsFile}`);
+function extractTypes(jsContent) {
+  const regex = /this\.initChart\("\.([A-Za-z0-9]+)",\s*this\.(\w+),\s*"(\w+)"\)/g;
+  const matches = {};
+  let m;
+  while ((m = regex.exec(jsContent))) {
+    matches[m[3]] = m[2];
   }
-  const data = JSON.parse(fs.readFileSync(chartsFile, 'utf8'));
-  const charts = data.charts || [];
-  charts.forEach((chart) => {
-    if (!chart.id) return;
-    const compDir = path.join(outputDir, toKebab(chart.id));
-    ensureDir(compDir);
-    const templates = renderTemplates(chart, templateDir);
-    fs.writeFileSync(path.join(compDir, `${toKebab(chart.id)}.js`), templates.js);
-    fs.writeFileSync(path.join(compDir, `${toKebab(chart.id)}.html`), templates.html);
-    fs.writeFileSync(path.join(compDir, `${toKebab(chart.id)}.js-meta.xml`), templates.xml);
+  const typeMap = { chartAOptions: 'bar', chartBoxOptions: 'box-and-whisker' };
+  const result = {};
+  Object.entries(matches).forEach(([name, opt]) => {
+    result[name] = typeMap[opt] || 'bar';
   });
-  return charts.length;
+  return result;
 }
 
-if (require.main === module) {
+function generateRevEng({
+  jsFile = 'force-app/main/default/lwc/dynamicCharts/dynamicCharts.js',
+  htmlFile = 'force-app/main/default/lwc/dynamicCharts/dynamicCharts.html',
+  outputFile = 'revEngCharts.json',
+  silent = false
+} = {}) {
+  if (!fs.existsSync(jsFile)) {
+    throw new Error(`JS file not found: ${jsFile}`);
+  }
+  if (!fs.existsSync(htmlFile)) {
+    throw new Error(`HTML file not found: ${htmlFile}`);
+  }
+
+  const jsContent = fs.readFileSync(jsFile, 'utf8');
+  const settings = extractChartSettings(jsContent);
+  const types = extractTypes(jsContent);
+
+  const charts = Object.entries(settings).map(([id, def]) => {
+    const style = {};
+    if (def.colors) {
+      style.seriesColors = def.colors.join(',');
+    }
+    style.font = 'default';
+    if (def.effects) {
+      style.effects = def.effects;
+    }
+    return {
+      dashboard: def.dashboard,
+      id,
+      type: types[id] || 'bar',
+      title: def.title,
+      fieldMappings: def.fieldMappings,
+      style
+    };
+  });
+
+  const result = { charts };
+  fs.writeFileSync(outputFile, JSON.stringify(result, null, 2));
+  if (!silent) {
+    console.log(`Wrote ${charts.length} charts to ${outputFile}`);
+  }
+  return result;
+}
+
+function runCLI() {
   const opts = {};
   process.argv.slice(2).forEach((arg) => {
-    if (arg.startsWith('--charts-file=')) {
-      opts.chartsFile = arg.split('=')[1];
-    } else if (arg.startsWith('--output-dir=')) {
-      opts.outputDir = arg.split('=')[1];
-    } else if (arg.startsWith('--template-dir=')) {
-      opts.templateDir = arg.split('=')[1];
+    if (arg.startsWith('--js-file=')) {
+      opts.jsFile = arg.split('=')[1];
+    } else if (arg.startsWith('--html-file=')) {
+      opts.htmlFile = arg.split('=')[1];
+    } else if (arg.startsWith('--output-file=')) {
+      opts.outputFile = arg.split('=')[1];
+    } else if (arg === '--silent') {
+      opts.silent = true;
     } else if (arg === '--help' || arg === '-h') {
-      console.log('Usage: node lwcReader.js [--charts-file file] [--output-dir dir] [--template-dir dir]');
+      console.log(
+        'Usage: node lwcReader.js [--js-file file] [--html-file file] [--output-file file] [--silent]'
+      );
       process.exit(0);
     }
   });
   try {
-    const count = generateLWCs(opts);
-    console.log(`Generated ${count} components`);
+    generateRevEng(opts);
   } catch (e) {
     console.error(e.message);
     process.exit(1);
   }
 }
 
-module.exports = generateLWCs;
+if (require.main === module) {
+  runCLI();
+}
+
+module.exports = generateRevEng;

--- a/test/lwcReader.test.js
+++ b/test/lwcReader.test.js
@@ -1,37 +1,37 @@
 const fs = require('fs');
 const path = require('path');
-const generateLWCs = require('../scripts/agents/lwcReader');
+const parseLWC = require('../scripts/agents/lwcReader');
 
 describe('lwcReader', () => {
   const tmpDir = path.join(__dirname, 'lwc');
-  const chartsFile = path.join(tmpDir, 'charts.json');
+  const jsFile = path.join(tmpDir, 'dynamicCharts.js');
+  const htmlFile = path.join(tmpDir, 'dynamicCharts.html');
+  const outFile = path.join(tmpDir, 'rev.json');
 
   beforeEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
     fs.mkdirSync(tmpDir, { recursive: true });
+    fs.copyFileSync(
+      path.resolve(__dirname, '../force-app/main/default/lwc/dynamicCharts/dynamicCharts.js'),
+      jsFile
+    );
+    fs.copyFileSync(
+      path.resolve(__dirname, '../force-app/main/default/lwc/dynamicCharts/dynamicCharts.html'),
+      htmlFile
+    );
   });
 
-  test('generates lwc components for each chart', () => {
-    const charts = {
-      charts: [
-        { id: 'TestChart', type: 'bar', title: 'Test Chart', fieldMappings: {} }
-      ]
-    };
-    fs.writeFileSync(chartsFile, JSON.stringify(charts));
-
-    const count = generateLWCs({ chartsFile, outputDir: tmpDir });
-    expect(count).toBe(1);
-
-    const compPath = path.join(tmpDir, 'test-chart');
-    expect(fs.existsSync(path.join(compPath, 'test-chart.js'))).toBe(true);
-    expect(fs.existsSync(path.join(compPath, 'test-chart.html'))).toBe(true);
-    expect(fs.existsSync(path.join(compPath, 'test-chart.js-meta.xml'))).toBe(true);
-
-    const jsContent = fs.readFileSync(path.join(compPath, 'test-chart.js'), 'utf8');
-    expect(jsContent).toContain('class TestChart');
+  test('parses chart settings and writes file', () => {
+    const result = parseLWC({ jsFile, htmlFile, outputFile: outFile, silent: true });
+    const data = JSON.parse(fs.readFileSync(outFile, 'utf8'));
+    expect(data).toEqual(result);
+    expect(data.charts.length).toBe(3);
+    const ids = data.charts.map(c => c.id).sort();
+    expect(ids).toEqual(['CampsByPeak', 'ClimbsByNation', 'TimeByPeak'].sort());
   });
 
-  test('throws when charts file missing', () => {
-    expect(() => generateLWCs({ chartsFile, outputDir: tmpDir })).toThrow(/charts file not found/);
+  test('throws when js file missing', () => {
+    fs.unlinkSync(jsFile);
+    expect(() => parseLWC({ jsFile, htmlFile, outputFile: outFile })).toThrow(/JS file not found/);
   });
 });


### PR DESCRIPTION
## Summary
- overhaul lwcReader docs to describe reverse-engineering mode
- implement new parser for dynamicCharts.js that writes revEngCharts.json
- adjust system design and requirements to match new behavior
- add tests for lwcReader parsing functionality

## Testing
- `npx jest test/lwcReader.test.js`
- `npm test` *(fails: dashboardReader.test.js, dashboardRetriever.test.js, changeRequestGenerator.test.js, sfdcDeployer.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684cc687a73883279b201c949580878a