### PR TITLE
Add per-agent test scripts

### DIFF
--- a/docs/DeveloperInstructions.md
+++ b/docs/DeveloperInstructions.md
@@ -37,5 +37,5 @@ Starting with this release, `scripts/changeRequestInterpreter.js` maps each chan
    - Delete all references to the `DaysPerPeak` chart including option objects, render calls and markup containers.
 
 4. **Validate Changes**
-   - Run `npm run test:unit` to ensure all Jest tests pass.
+   - Run `npm run test:<agent>` (for example, `npm run test:changeRequestGenerator`) to ensure all Jest tests pass.
 

--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -76,6 +76,7 @@ All automation scripts assume a Node.js 18 runtime. Using older or unsupported v
 Unit tests reside under `force-app/main/default/lwc/dynamicCharts/__tests__` and use `sfdx-lwc-jest`. Additional Apex test classes are stored in the `force-app/test` package to validate server-side code. The root `test` directory contains integration checks—for example, verifying that chart container IDs (and their `AO` counterparts) match the chart definitions in `charts.json`.
 The suite also verifies that each chart container creates an ApexCharts instance by mocking `lightning/platformResourceLoader` to load the real library.
 Test execution is orchestrated by the `lwcTester` agent which installs required dev dependencies, scaffolds `test/lwcTester`, and runs Jest with coverage thresholds prior to deployment.
+Each agent's tests can be run individually using npm scripts such as `npm run test:changeRequestGenerator`.
 
 ## Future Considerations
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -65,6 +65,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
 5. **Testing**
    - Automated tests shall verify that each chart container successfully initializes an ApexCharts instance.
 - A Node script named `lwcTester` shall run Jest unit and integration tests from `test/lwcTester` and enforce minimum coverage of 80% statements, 75% branches, 80% functions, and 80% lines before deployment.
+- Each agent's tests shall be runnable individually via npm scripts such as `npm run test:changeRequestGenerator`.
 - A Node script named `sfdcDeployer` shall deploy metadata using the `sf` CLI and write a deployment report under `reports`.
 - Development tooling such as the Salesforce CLI and Jest shall be listed under `devDependencies` in `package.json` so `npm install` fully sets up the environment.
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,15 @@
     "precommit": "lint-staged",
     "generate:charts": "node scripts/agents/sfdcAuthorizer.js && node scripts/agents/dashboardRetriever.js && node scripts/agents/dashboardReader.js && node scripts/agents/lwcReader.js && node scripts/agents/changeRequestGenerator.js",
     "sync:charts": "node scripts/agents/syncCharts.js",
-    "deploy:charts": "npm run test:unit && node scripts/agents/lwcTester.js && node scripts/agents/sfdcDeployer.js"
+    "deploy:charts": "npm run test:unit && node scripts/agents/lwcTester.js && node scripts/agents/sfdcDeployer.js",
+    "test:sfdcAuthorizer": "jest test/sfdcAuthorizer.test.js",
+    "test:dashboardRetriever": "jest test/dashboardRetriever.test.js",
+    "test:dashboardReader": "jest test/dashboardReader.test.js",
+    "test:lwcReader": "jest test/lwcReader.test.js",
+    "test:changeRequestGenerator": "jest test/changeRequestGenerator.test.js",
+    "test:syncCharts": "jest test/syncCharts.test.js",
+    "test:lwcTester": "jest test/lwcTester.test.js",
+    "test:sfdcDeployer": "jest test/sfdcDeployer.test.js"
   },
   "devDependencies": {
     "@lwc/eslint-plugin-lwc": "^2.2.0",


### PR DESCRIPTION
## Summary
- add dedicated npm scripts for each agent's tests
- document new commands in design and requirements docs
- update developer instructions for running per-agent tests

## Testing
- `npm run test:changeRequestGenerator`
- `npm run test:dashboardRetriever` *(fails: toHaveBeenCalledWith expectation mismatch)*
- `npm run test:sfdcAuthorizer` *(fails: process.exit called)*

------
https://chatgpt.com/codex/tasks/task_e_684cd5e159548327a07d811e65fbea75