### PR TITLE
Allow Node 22

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -10,7 +10,7 @@ The objective of this system is twofold:
    Because the reporting lifecycle is to be kept separate from the application lifecycle, with no audit trail necessary, specific dashboard requrirements are meant to be left out of SDD and SRDs
 
 The project follows the Salesforce DX structure with source located under `force-app/main/default` and uses `sfdx-lwc-jest` for unit testing.
-All automation scripts assume a Node.js 18 runtime. Using older or unsupported versions may cause `npm install` failures or other issues with the Salesforce CLI.
+All automation scripts assume a Node.js 18 or later runtime (tested with Node.js 22). Using older or unsupported versions may cause `npm install` failures or other issues with the Salesforce CLI.
 
 ## Architecture
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -43,7 +43,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - A vertical unordered list on the left shall allow users to select which chart page is displayed. Each chart pair occupies its own page.
 9. **Compatibility**
    - The application shall be compatible with Salesforce API version 59.0 as specified in the `sfdx-project.json` configuration.
-   - Development tooling shall run on Node.js 18 LTS. Using unsupported Node versions may prevent `npm install` from completing successfully.
+   - Development tooling shall run on Node.js 18 or later (tested with Node.js 22). Using unsupported Node versions may prevent `npm install` from completing successfully.
 10. **Change Request Generation**
 
 - A Node script named `changeRequestGenerator` shall compare `charts.json` with `revEngCharts.json` and output both `changeRequests.json` and a developer-oriented `changeRequestInstructions.txt` file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
         "semver": "^7.5.4",
       },
       "engines": {
-        "node": ">=18 <21"
+        "node": ">=18 <23"
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Salesforce App",
   "engines": {
-    "node": ">=18 <21"
+    "node": ">=18 <23"
   },
   "scripts": {
     "preinstall": "node scripts/checkNodeVersion.js",

--- a/scripts/checkNodeVersion.js
+++ b/scripts/checkNodeVersion.js
@@ -1,5 +1,5 @@
 const semver = require('semver');
-const required = '>=18 <21';
+const required = '>=18 <23';
 if (!semver.satisfies(process.version, required)) {
   console.error(`Error: Node.js ${required} required. Current version ${process.version}.`);
   process.exit(1);

--- a/test/checkNodeVersion.test.js
+++ b/test/checkNodeVersion.test.js
@@ -15,8 +15,14 @@ describe('checkNodeVersion', () => {
     expect(code).toBe(1);
   });
 
-  test('succeeds for supported version', () => {
+  test('succeeds for supported version 18', () => {
     const cmd = `node -e "Object.defineProperty(process,'version',{value:'v18.0.0',configurable:true});require('${script.replace(/\\/g,'\\\\')}');"`;
+    const result = execSync(cmd, {stdio: 'pipe'});
+    expect(result.toString()).toBe('');
+  });
+
+  test('succeeds for supported version 22', () => {
+    const cmd = `node -e "Object.defineProperty(process,'version',{value:'v22.0.0',configurable:true});require('${script.replace(/\\/g,'\\\\')}');"`;
     const result = execSync(cmd, {stdio: 'pipe'});
     expect(result.toString()).toBe('');
   });


### PR DESCRIPTION
## Summary
- permit Node.js up to v22 in engine check
- document that Node.js 18+ (tested with Node 22) is supported
- update unit tests for version check

## Testing
- `npx jest test/checkNodeVersion.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684d481ba10c8327af0ab7cb16fa3fb6