### PR TITLE
Add end-to-end workflow

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -67,8 +67,9 @@ All automation scripts assume a Node.js 18 or later runtime (tested with Node.js
  - **dashboardReader**: Parses exported dashboard JSON into normalized chart definitions written to `charts.json`. The parser now supports dashboard files where the `widgets` section is expressed as an object rather than an array.
  - **lwcReader**: Parses the existing `dynamicCharts` component to generate `revEngCharts.json` describing the charts currently implemented.
  - **changeRequestGenerator**: Compares `charts.json` with `revEngCharts.json` to produce `changeRequests.json` and a detailed `changeRequestInstructions.txt` file for developers.
- - **syncCharts**: Reads `changeRequests.json` and updates the `dynamicCharts` LWC by modifying the HTML and JS files via AST transforms. The agent applies each change request's mismatched properties directly to the `chartSettings` object so dashboard references, titles, field mappings and style options remain aligned with the CRM Analytics definitions.
+- **syncCharts**: Reads `changeRequests.json` and updates the `dynamicCharts` LWC by modifying the HTML and JS files via AST transforms. The agent applies each change request's mismatched properties directly to the `chartSettings` object so dashboard references, titles, field mappings and style options remain aligned with the CRM Analytics definitions.
 - **sfdcDeployer**: Deploys metadata in `force-app/main/default` to the target org using the `sf` CLI and writes a JSON report under `reports/`.
+- **endToEndCharts.js**: Runs all agents in sequence. Executed via `npm run end-to-end:charts` to authenticate, retrieve dashboards, parse them, sync charts, run tests and deploy.
 - **Salesforce CLI** and **Jest** are included in `devDependencies` so running `npm install` prepares the full toolchain automatically.
 
 ## Testing

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -50,6 +50,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
 - The instructions file shall translate style changes into their corresponding ApexCharts option paths so developers can implement updates precisely.
 - A Node script named `syncCharts` shall apply `changeRequests.json` to update `dynamicCharts.html` and `dynamicCharts.js` automatically.
 - A Node script named `syncCharts` shall apply `changeRequests.json` to update `dynamicCharts.html` and `dynamicCharts.js` automatically. Updates must modify the `chartSettings` object when mismatched properties specify new dashboard names, titles, field mappings, or style values.
+- A Node script named `endToEndCharts` shall run all agents sequentially. It shall be exposed through the npm command `end-to-end:charts`.
 
 ## Non‑Functional Requirements
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "generate:charts": "node scripts/agents/sfdcAuthorizer.js && node scripts/agents/dashboardRetriever.js && node scripts/agents/dashboardReader.js && node scripts/agents/lwcReader.js && node scripts/agents/changeRequestGenerator.js",
     "sync:charts": "node scripts/agents/syncCharts.js",
     "deploy:charts": "npm run test:unit && node scripts/agents/lwcTester.js && node scripts/agents/sfdcDeployer.js",
+    "end-to-end:charts": "node scripts/endToEndCharts.js",
     "test:sfdcAuthorizer": "jest test/sfdcAuthorizer.test.js",
     "test:dashboardRetriever": "jest test/dashboardRetriever.test.js",
     "test:dashboardReader": "jest test/dashboardReader.test.js",

--- a/scripts/endToEndCharts.js
+++ b/scripts/endToEndCharts.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+const sfdcAuthorizer = require('./agents/sfdcAuthorizer');
+const dashboardRetriever = require('./agents/dashboardRetriever');
+const dashboardReader = require('./agents/dashboardReader');
+const lwcReader = require('./agents/lwcReader');
+const changeRequestGenerator = require('./agents/changeRequestGenerator');
+const syncCharts = require('./agents/syncCharts');
+const lwcTester = require('./agents/lwcTester');
+const sfdcDeployer = require('./agents/sfdcDeployer');
+
+function runEndToEnd() {
+  sfdcAuthorizer();
+  dashboardRetriever();
+  dashboardReader();
+  lwcReader();
+  changeRequestGenerator();
+  syncCharts();
+  lwcTester();
+  sfdcDeployer();
+}
+
+if (require.main === module) {
+  runEndToEnd();
+}
+
+module.exports = runEndToEnd;

--- a/test/endToEndCharts.test.js
+++ b/test/endToEndCharts.test.js
@@ -1,0 +1,47 @@
+jest.mock('../scripts/agents/sfdcAuthorizer', () => jest.fn());
+jest.mock('../scripts/agents/dashboardRetriever', () => jest.fn());
+jest.mock('../scripts/agents/dashboardReader', () => jest.fn());
+jest.mock('../scripts/agents/lwcReader', () => jest.fn());
+jest.mock('../scripts/agents/changeRequestGenerator', () => jest.fn());
+jest.mock('../scripts/agents/syncCharts', () => jest.fn());
+jest.mock('../scripts/agents/lwcTester', () => jest.fn());
+jest.mock('../scripts/agents/sfdcDeployer', () => jest.fn());
+
+const sfdcAuthorizer = require('../scripts/agents/sfdcAuthorizer');
+const dashboardRetriever = require('../scripts/agents/dashboardRetriever');
+const dashboardReader = require('../scripts/agents/dashboardReader');
+const lwcReader = require('../scripts/agents/lwcReader');
+const changeRequestGenerator = require('../scripts/agents/changeRequestGenerator');
+const syncCharts = require('../scripts/agents/syncCharts');
+const lwcTester = require('../scripts/agents/lwcTester');
+const sfdcDeployer = require('../scripts/agents/sfdcDeployer');
+
+const runEndToEnd = require('../scripts/endToEndCharts');
+
+function callOrder(mockFn) {
+  return mockFn.mock.invocationCallOrder[0] || 0;
+}
+
+describe('endToEndCharts workflow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('runs agents in sequence', () => {
+    runEndToEnd();
+    const order = [
+      sfdcAuthorizer,
+      dashboardRetriever,
+      dashboardReader,
+      lwcReader,
+      changeRequestGenerator,
+      syncCharts,
+      lwcTester,
+      sfdcDeployer,
+    ].map(callOrder);
+
+    for (let i = 0; i < order.length - 1; i++) {
+      expect(order[i]).toBeLessThan(order[i + 1]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `endToEndCharts.js` workflow script
- add npm command `end-to-end:charts`
- test the workflow ordering
- document the new workflow in design and requirements

## Testing
- `npx jest --runInBand --silent` *(fails: dashboardRetriever.test.js, sfdcDeployer.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684d4a22ad148327bb72a79d91f65d25