### PR TITLE
Enable dashboard selection for end-to-end workflow

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -69,12 +69,14 @@ All automation scripts assume a Node.js 18 or later runtime (tested with Node.js
  - **changeRequestGenerator**: Compares `charts.json` with `revEngCharts.json` to produce `changeRequests.json` and a detailed `changeRequestInstructions.txt` file for developers.
 - **syncCharts**: Reads `changeRequests.json` and updates the `dynamicCharts` LWC by modifying the HTML and JS files via AST transforms. The agent applies each change request's mismatched properties directly to the `chartSettings` object so dashboard references, titles, field mappings and style options remain aligned with the CRM Analytics definitions.
 - **sfdcDeployer**: Deploys metadata in `force-app/main/default` to the target org using the `sf` CLI and writes a JSON report under `reports/`.
-- **endToEndCharts.js**: Runs all agents in sequence. Executed via `npm run end-to-end:charts` to authenticate, retrieve dashboards, parse them, sync charts, run tests and deploy.
+- **endToEndCharts.js**: Runs all agents in sequence. Executed via `npm run end-to-end:charts --dashboard=CR_02` to authenticate, retrieve dashboards, parse them, sync charts, run tests and deploy.
 - **Salesforce CLI** and **Jest** are included in `devDependencies` so running `npm install` prepares the full toolchain automatically.
 
 Each agent also has a dedicated npm script named after the agent. For example,
 `npm run dashboardRetriever --dashboard=CR_02` passes the dashboard API name to
 `dashboardRetriever.js` and `dashboardReader.js` uses the same parameter.
+The full workflow script `end-to-end:charts` accepts this option as well so that all
+agents operate on the specified dashboard.
 
 ## Testing
 

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -50,7 +50,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
 - The instructions file shall translate style changes into their corresponding ApexCharts option paths so developers can implement updates precisely.
 - A Node script named `syncCharts` shall apply `changeRequests.json` to update `dynamicCharts.html` and `dynamicCharts.js` automatically.
 - A Node script named `syncCharts` shall apply `changeRequests.json` to update `dynamicCharts.html` and `dynamicCharts.js` automatically. Updates must modify the `chartSettings` object when mismatched properties specify new dashboard names, titles, field mappings, or style values.
-- A Node script named `endToEndCharts` shall run all agents sequentially. It shall be exposed through the npm command `end-to-end:charts`.
+- A Node script named `endToEndCharts` shall run all agents sequentially. It shall be exposed through the npm command `end-to-end:charts`. The command accepts `--dashboard=<name>` to pass the dashboard API name to `dashboardRetriever` and `dashboardReader`.
 
 ## Non‑Functional Requirements
 

--- a/scripts/endToEndCharts.js
+++ b/scripts/endToEndCharts.js
@@ -9,10 +9,10 @@ const syncCharts = require('./agents/syncCharts');
 const lwcTester = require('./agents/lwcTester');
 const sfdcDeployer = require('./agents/sfdcDeployer');
 
-function runEndToEnd() {
+function runEndToEnd({ dashboard } = {}) {
   sfdcAuthorizer();
-  dashboardRetriever();
-  dashboardReader();
+  dashboardRetriever({ dashboardApiName: dashboard });
+  dashboardReader({ dashboardApiName: dashboard });
   lwcReader();
   changeRequestGenerator();
   syncCharts();
@@ -21,7 +21,15 @@ function runEndToEnd() {
 }
 
 if (require.main === module) {
-  runEndToEnd();
+  const opts = {};
+  process.argv.slice(2).forEach((arg) => {
+    if (arg.startsWith('--dashboard=')) {
+      opts.dashboard = arg.split('=')[1];
+    } else if (arg.startsWith('--dashboard-api-name=')) {
+      opts.dashboard = arg.split('=')[1];
+    }
+  });
+  runEndToEnd(opts);
 }
 
 module.exports = runEndToEnd;

--- a/test/endToEndCharts.test.js
+++ b/test/endToEndCharts.test.js
@@ -27,8 +27,10 @@ describe('endToEndCharts workflow', () => {
     jest.clearAllMocks();
   });
 
-  test('runs agents in sequence', () => {
-    runEndToEnd();
+  test('runs agents in sequence with dashboard parameter', () => {
+    runEndToEnd({ dashboard: 'CR_02' });
+    expect(dashboardRetriever).toHaveBeenCalledWith({ dashboardApiName: 'CR_02' });
+    expect(dashboardReader).toHaveBeenCalledWith({ dashboardApiName: 'CR_02' });
     const order = [
       sfdcAuthorizer,
       dashboardRetriever,


### PR DESCRIPTION
## Summary
- allow `scripts/endToEndCharts.js` to accept a `--dashboard` argument
- wire the dashboard argument through to `dashboardRetriever` and `dashboardReader`
- test the new behaviour
- document passing `--dashboard` to the end-to-end workflow in design and requirements docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d54a2eebc8327851ec2860471f1e5