### PR TITLE
Fix syncCharts defaults

### DIFF
--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -48,8 +48,8 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
 
 - A Node script named `changeRequestGenerator` shall compare `charts.json` with `revEngCharts.json` and output both `changeRequests.json` and a developer-oriented `changeRequestInstructions.txt` file.
 - The instructions file shall translate style changes into their corresponding ApexCharts option paths so developers can implement updates precisely.
-- A Node script named `syncCharts` shall apply `changeRequests.json` to update `dynamicCharts.html` and `dynamicCharts.js` automatically.
-- A Node script named `syncCharts` shall apply `changeRequests.json` to update `dynamicCharts.html` and `dynamicCharts.js` automatically. Updates must modify the `chartSettings` object when mismatched properties specify new dashboard names, titles, field mappings, or style values.
+- A Node script named `syncCharts` shall apply `changeRequests.json` to update `dynamicCharts.html` and `dynamicCharts.js` automatically. The script defaults to `force-app/main/default/lwc/dynamicCharts/dynamicCharts.html` and `force-app/main/default/lwc/dynamicCharts/dynamicCharts.js` when paths are not provided.
+- The `syncCharts` agent shall modify the `chartSettings` object when mismatched properties specify new dashboard names, titles, field mappings, or style values.
 - A Node script named `endToEndCharts` shall run all agents sequentially. It shall be exposed through the npm command `end-to-end:charts`. The command accepts `--dashboard=<name>` to pass the dashboard API name to `dashboardRetriever` and `dashboardReader`.
 
 ## Non‑Functional Requirements

--- a/docs/agents/syncCharts.md
+++ b/docs/agents/syncCharts.md
@@ -36,9 +36,9 @@ The `syncCharts` agent merges the functionality of the `changeRequestInterpreter
 node scripts/agents/syncCharts.js --input changeRequests.json --html force-app/main/default/lwc/dynamicCharts/dynamicCharts.html --js force-app/main/default/lwc/dynamicCharts/dynamicCharts.js
 ```
 
-- `--input` (`-i`): Path to `changeRequests.json`.
-- `--html` (`-h`): Path to `dynamicCharts.html`.
-- `--js` (`-j`): Path to `dynamicCharts.js`.
+- `--input` (`-i`): Path to `changeRequests.json`. Defaults to `changeRequests.json`.
+- `--html` (`-h`): Path to `dynamicCharts.html`. Defaults to `force-app/main/default/lwc/dynamicCharts/dynamicCharts.html`.
+- `--js` (`-j`): Path to `dynamicCharts.js`. Defaults to `force-app/main/default/lwc/dynamicCharts/dynamicCharts.js`.
 
 ## Example
 

--- a/scripts/agents/syncCharts.js
+++ b/scripts/agents/syncCharts.js
@@ -124,7 +124,11 @@ function updateHtml(htmlPath, changes) {
   fs.writeFileSync(htmlPath, lines.join('\n'));
 }
 
-function syncCharts({ input = 'changeRequests.json', html, js }) {
+function syncCharts({
+  input = 'changeRequests.json',
+  html = 'force-app/main/default/lwc/dynamicCharts/dynamicCharts.html',
+  js = 'force-app/main/default/lwc/dynamicCharts/dynamicCharts.js'
+} = {}) {
   if (!html || !js) {
     throw new Error('html and js options are required');
   }

--- a/test/syncCharts.test.js
+++ b/test/syncCharts.test.js
@@ -62,4 +62,28 @@ describe('syncCharts', () => {
     expect(updated).toMatch(/colors:\s*\[\s*"#175F68"\s*\]/);
     expect(updated).toMatch(/effects:\s*\[\s*"shadow"\s*\]/);
   });
+
+  test('uses default file paths when options are omitted', () => {
+    const cwd = process.cwd();
+    const defaultDir = path.join(tmpDir, 'proj');
+    const defaultLwcDir = path.join(
+      defaultDir,
+      'force-app/main/default/lwc/dynamicCharts'
+    );
+    fs.mkdirSync(defaultLwcDir, { recursive: true });
+    fs.copyFileSync(htmlPath, path.join(defaultLwcDir, 'dynamicCharts.html'));
+    fs.copyFileSync(jsPath, path.join(defaultLwcDir, 'dynamicCharts.js'));
+    fs.copyFileSync(inputPath, path.join(defaultDir, 'changeRequests.json'));
+    process.chdir(defaultDir);
+    try {
+      syncCharts();
+      const updated = fs.readFileSync(
+        path.join(defaultLwcDir, 'dynamicCharts.js'),
+        'utf8'
+      );
+      expect(updated).toContain('dashboard: "CR_02"');
+    } finally {
+      process.chdir(cwd);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- default all `syncCharts` options so it can be called with no arguments
- document default HTML/JS paths for `syncCharts`
- mention defaults in system requirements
- test default path behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d5c21821c8327a335db6ddfabee1b