### PR TITLE
Fix syncCharts parser and update layout handling

### DIFF
--- a/scripts/agents/lwcReader.js
+++ b/scripts/agents/lwcReader.js
@@ -5,14 +5,32 @@ const fs = require('fs');
 const path = require('path');
 
 function extractChartSettings(jsContent) {
-  const start = jsContent.indexOf('chartSettings = {');
+  const marker = 'chartSettings =';
+  const start = jsContent.indexOf(marker);
   if (start === -1) {
     return {};
   }
-  const end = jsContent.indexOf('};', start);
-  const objectSource = jsContent.slice(start + 'chartSettings = '.length, end + 1);
+  const open = jsContent.indexOf('{', start);
+  if (open === -1) {
+    return {};
+  }
+  let idx = open;
+  let depth = 0;
+  while (idx < jsContent.length) {
+    const ch = jsContent[idx];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        idx += 1;
+        break;
+      }
+    }
+    idx += 1;
+  }
+  const objText = jsContent.slice(open, idx);
   // eslint-disable-next-line no-new-func
-  return new Function(`return ${objectSource}`)();
+  return new Function(`return (${objText})`)();
 }
 
 function extractTypes(jsContent) {

--- a/scripts/agents/syncCharts.js
+++ b/scripts/agents/syncCharts.js
@@ -32,7 +32,8 @@ function parseChartSettings(jsText) {
   const objText = jsText.slice(open, idx);
   const obj = vm.runInNewContext('(' + objText + ')');
   const semicolonIdx = jsText.indexOf(';', idx);
-  return { obj, start, open, end: semicolonIdx + 1 };
+  const end = semicolonIdx === -1 ? idx : semicolonIdx + 1;
+  return { obj, start, open, end };
 }
 
 function serializeSettings(obj) {
@@ -83,7 +84,7 @@ function updateHtml(htmlPath, changes) {
   let lines = fs.readFileSync(htmlPath, 'utf8').split(/\r?\n/);
   const ulStart = lines.findIndex((l) => l.includes('<ul') && l.includes('slds-list_dotted'));
   let ulEnd = lines.findIndex((l, i) => i > ulStart && l.includes('</ul>'));
-  const layoutEnd = lines.lastIndexOf('</lightning-layout-item>');
+  let layoutEnd = lines.lastIndexOf('</lightning-layout-item>');
   changes.changes.forEach((change) => {
     if (change.targetFile !== 'dynamicCharts.js') return;
     const id = change.chartId;


### PR DESCRIPTION
## Summary
- improve chart settings parsing for lwcReader
- make syncCharts robust for missing semicolon and update layout index

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_684d6d6a9b088327bb1588b2b6d43cd8