### PR TITLE
Support env var for end-to-end dashboard option

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -69,7 +69,7 @@ All automation scripts assume a Node.js 18 or later runtime (tested with Node.js
  - **changeRequestGenerator**: Compares `charts.json` with `revEngCharts.json` to produce `changeRequests.json` and a detailed `changeRequestInstructions.txt` file for developers.
 - **syncCharts**: Reads `changeRequests.json` and updates the `dynamicCharts` LWC by modifying the HTML and JS files via AST transforms. The agent applies each change request's mismatched properties directly to the `chartSettings` object so dashboard references, titles, field mappings and style options remain aligned with the CRM Analytics definitions.
 - **sfdcDeployer**: Deploys metadata in `force-app/main/default` to the target org using the `sf` CLI and writes a JSON report under `reports/`.
-- **endToEndCharts.js**: Runs all agents in sequence. Executed via `npm run end-to-end:charts --dashboard=CR_02` to authenticate, retrieve dashboards, parse them, sync charts, run tests and deploy.
+ - **endToEndCharts.js**: Runs all agents in sequence. Executed via `npm run end-to-end:charts -- --dashboard=CR_02` (or set `--dashboard=CR_02` so npm populates `npm_config_dashboard`) to authenticate, retrieve dashboards, parse them, sync charts, run tests and deploy.
 - **Salesforce CLI** and **Jest** are included in `devDependencies` so running `npm install` prepares the full toolchain automatically.
 
 Each agent also has a dedicated npm script named after the agent. For example,

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -50,7 +50,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
 - The instructions file shall translate style changes into their corresponding ApexCharts option paths so developers can implement updates precisely.
 - A Node script named `syncCharts` shall apply `changeRequests.json` to update `dynamicCharts.html` and `dynamicCharts.js` automatically. The script defaults to `force-app/main/default/lwc/dynamicCharts/dynamicCharts.html` and `force-app/main/default/lwc/dynamicCharts/dynamicCharts.js` when paths are not provided.
 - The `syncCharts` agent shall modify the `chartSettings` object when mismatched properties specify new dashboard names, titles, field mappings, or style values.
-- A Node script named `endToEndCharts` shall run all agents sequentially. It shall be exposed through the npm command `end-to-end:charts`. The command accepts `--dashboard=<name>` to pass the dashboard API name to `dashboardRetriever` and `dashboardReader`.
+ - A Node script named `endToEndCharts` shall run all agents sequentially. It shall be exposed through the npm command `end-to-end:charts`. The command accepts `--dashboard=<name>` or reads the `npm_config_dashboard` environment variable to pass the dashboard API name to `dashboardRetriever` and `dashboardReader`.
 
 ## Non‑Functional Requirements
 

--- a/scripts/endToEndCharts.js
+++ b/scripts/endToEndCharts.js
@@ -10,9 +10,10 @@ const lwcTester = require('./agents/lwcTester');
 const sfdcDeployer = require('./agents/sfdcDeployer');
 
 function runEndToEnd({ dashboard } = {}) {
+  const dash = dashboard || process.env.npm_config_dashboard;
   sfdcAuthorizer();
-  dashboardRetriever({ dashboardApiName: dashboard });
-  dashboardReader({ dashboardApiName: dashboard });
+  dashboardRetriever({ dashboardApiName: dash });
+  dashboardReader({ dashboardApiName: dash });
   lwcReader();
   changeRequestGenerator();
   syncCharts();

--- a/test/endToEndCharts.test.js
+++ b/test/endToEndCharts.test.js
@@ -46,4 +46,11 @@ describe('endToEndCharts workflow', () => {
       expect(order[i]).toBeLessThan(order[i + 1]);
     }
   });
+
+  test('reads dashboard from npm_config_dashboard env var', () => {
+    process.env.npm_config_dashboard = 'ENV_02';
+    runEndToEnd();
+    expect(dashboardRetriever).toHaveBeenCalledWith({ dashboardApiName: 'ENV_02' });
+    expect(dashboardReader).toHaveBeenCalledWith({ dashboardApiName: 'ENV_02' });
+  });
 });


### PR DESCRIPTION
## Summary
- support `npm_config_dashboard` in `endToEndCharts.js`
- document passing `--dashboard` argument or using `npm_config_dashboard`
- test environment variable handling

## Testing
- `npm test` *(fails: sfdx-lwc-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2a0a0c7c83279f2656c2f650cc40