### PR TITLE
Improve dashboard retrieval error handling

### DIFF
--- a/scripts/agents/dashboardReader.js
+++ b/scripts/agents/dashboardReader.js
@@ -161,6 +161,13 @@ function readDashboard({
   }
 
   const dashboard = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  if (
+    dashboard.errorCode ||
+    (Array.isArray(dashboard) && dashboard[0]?.errorCode)
+  ) {
+    const msg = dashboard.message || dashboard[0]?.message || "Unknown error";
+    throw new Error(`Invalid dashboard JSON: ${msg}`);
+  }
   const state = dashboard.state || {};
   const steps = state.steps || {};
   const widgetsByName = state.widgets || {};

--- a/scripts/agents/dashboardRetriever.js
+++ b/scripts/agents/dashboardRetriever.js
@@ -92,6 +92,17 @@ function retrieveDashboard({
 
   // Fetch JSON from REST API
   const json = execSync(curlCmd, { encoding: "utf8" });
+  let parsed;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err) {
+    throw new Error(`Failed to parse dashboard JSON: ${err.message}`);
+  }
+
+  if (parsed.errorCode || (Array.isArray(parsed) && parsed[0]?.errorCode)) {
+    const msg = parsed.message || parsed[0]?.message || "Unknown error";
+    throw new Error(`Dashboard retrieval failed: ${msg}`);
+  }
 
   const outPath = path.join(outDir, `${dashboardApiName}.json`);
   fs.writeFileSync(outPath, json, "utf8");


### PR DESCRIPTION
## Summary
- validate REST response in `dashboardRetriever` before saving
- guard against invalid dashboard JSON in `dashboardReader`

## Testing
- `npm run test:lwc:unit`
- `npm run end-to-end:charts --dashboard=CR-02` *(fails early due to dashboard not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdfceb48c8327bd2011651c94e75c