### PR TITLE
Ensure lwcTester installs missing packages

### DIFF
--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -65,13 +65,13 @@ All automation scripts assume a Node.js 18 or later runtime (tested with Node.js
 - **lightning/analyticsWaveApi**: Provides `getDatasets` and `executeQuery` wire adapters.
 - **Salesforce LWC**: Standard library for creating Lightning Web Components.
 - **sfdcAuthorizer**: Node script that performs JWT-based authentication so other automation agents can access the org. The script first checks for `./tmp/access_token.txt` and verifies the token against Salesforce. If the token is accepted, the cached value is reused and login is skipped. The validation uses `SF_INSTANCE_URL` when available (falling back to `SFDC_LOGIN_URL`) so tokens are not refreshed unnecessarily.
- - **dashboardRetriever**: Downloads dashboard state JSON using the CRM Analytics REST API so parsing agents can generate `charts.json`. When a dashboard label is supplied, it first queries the REST API to determine the API name and validates the REST response for errors before saving.
- - **dashboardReader**: Parses exported dashboard JSON into normalized chart definitions written to `charts.json`. The parser now supports dashboard files where the `widgets` section is expressed as an object rather than an array and throws an error when the JSON contains an `errorCode` field.
- - **lwcReader**: Parses the existing `dynamicCharts` component to generate `revEngCharts.json` describing the charts currently implemented.
- - **changeRequestGenerator**: Compares `charts.json` with `revEngCharts.json` to produce `changeRequests.json` and a detailed `changeRequestInstructions.txt` file for developers.
+- **dashboardRetriever**: Downloads dashboard state JSON using the CRM Analytics REST API so parsing agents can generate `charts.json`. When a dashboard label is supplied, it first queries the REST API to determine the API name and validates the REST response for errors before saving.
+- **dashboardReader**: Parses exported dashboard JSON into normalized chart definitions written to `charts.json`. The parser now supports dashboard files where the `widgets` section is expressed as an object rather than an array and throws an error when the JSON contains an `errorCode` field.
+- **lwcReader**: Parses the existing `dynamicCharts` component to generate `revEngCharts.json` describing the charts currently implemented.
+- **changeRequestGenerator**: Compares `charts.json` with `revEngCharts.json` to produce `changeRequests.json` and a detailed `changeRequestInstructions.txt` file for developers.
 - **syncCharts**: Reads `changeRequests.json` and updates the `dynamicCharts` LWC by modifying the HTML and JS files via AST transforms. The agent applies each change request's mismatched properties directly to the `chartSettings` object so dashboard references, titles, field mappings and style options remain aligned with the CRM Analytics definitions.
 - **sfdcDeployer**: Deploys metadata in `force-app/main/default` to the target org using the `sf` CLI and writes a JSON report under `reports/`.
- - **endToEndCharts.js**: Runs all agents in sequence. Executed via `npm run end-to-end:charts -- --dashboard=CR_02` (or set `--dashboard=CR_02` so npm populates `npm_config_dashboard`) to authenticate, retrieve dashboards, parse them, sync charts, run tests and deploy.
+- **endToEndCharts.js**: Runs all agents in sequence. Executed via `npm run end-to-end:charts -- --dashboard=CR_02` (or set `--dashboard=CR_02` so npm populates `npm_config_dashboard`) to authenticate, retrieve dashboards, parse them, sync charts, run tests and deploy.
 - **Salesforce CLI** and **Jest** are included in `devDependencies` so running `npm install` prepares the full toolchain automatically.
 
 Each agent also has a dedicated npm script named after the agent. For example,
@@ -84,7 +84,7 @@ agents operate on the specified dashboard.
 
 Unit tests reside under `force-app/main/default/lwc/dynamicCharts/__tests__` and use `sfdx-lwc-jest`. Additional Apex test classes are stored in the `force-app/test` package to validate server-side code. The root `test` directory contains integration checks—for example, verifying that chart container IDs (and their `AO` counterparts) match the chart definitions in `charts.json`.
 The suite also verifies that each chart container creates an ApexCharts instance by mocking `lightning/platformResourceLoader` to load the real library.
-Test execution is orchestrated by the `lwcTester` agent which installs required dev dependencies, scaffolds `test/lwcTester`, and runs Jest with coverage thresholds prior to deployment.
+Test execution is orchestrated by the `lwcTester` agent which verifies that required dev dependencies are present in `node_modules`, installs any missing packages, scaffolds `test/lwcTester`, and runs Jest with coverage thresholds prior to deployment.
 Each agent's tests can be run individually using npm scripts such as `npm run test:changeRequestGenerator`.
 
 ## Future Considerations

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -56,7 +56,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
 - The instructions file shall translate style changes into their corresponding ApexCharts option paths so developers can implement updates precisely.
 - A Node script named `syncCharts` shall apply `changeRequests.json` to update `dynamicCharts.html` and `dynamicCharts.js` automatically. The script defaults to `force-app/main/default/lwc/dynamicCharts/dynamicCharts.html` and `force-app/main/default/lwc/dynamicCharts/dynamicCharts.js` when paths are not provided.
 - The `syncCharts` agent shall modify the `chartSettings` object when mismatched properties specify new dashboard names, titles, field mappings, or style values.
- - A Node script named `endToEndCharts` shall run all agents sequentially. It shall be exposed through the npm command `end-to-end:charts`. The command accepts `--dashboard=<name>` or reads the `npm_config_dashboard` environment variable to pass the dashboard API name to `dashboardRetriever` and `dashboardReader`.
+- A Node script named `endToEndCharts` shall run all agents sequentially. It shall be exposed through the npm command `end-to-end:charts`. The command accepts `--dashboard=<name>` or reads the `npm_config_dashboard` environment variable to pass the dashboard API name to `dashboardRetriever` and `dashboardReader`.
 
 ## Non‑Functional Requirements
 
@@ -74,10 +74,11 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - The system should allow additional chart types and datasets to be introduced with minimal code changes.
 5. **Testing**
    - Automated tests shall verify that each chart container successfully initializes an ApexCharts instance.
-- A Node script named `lwcTester` shall run Jest unit and integration tests from `test/lwcTester` and enforce minimum coverage of 80% statements, 75% branches, 80% functions, and 80% lines before deployment.
-  - Each agent's tests shall be runnable individually via npm scripts such as `npm run test:changeRequestGenerator`.
-  - Each agent shall have a dedicated npm script. Pass the dashboard API name using `--dashboard=<name>` when running `dashboardRetriever` or `dashboardReader`.
-  - A Node script named `sfdcDeployer` shall deploy metadata using the `sf` CLI and write a deployment report under `reports`.
+
+- A Node script named `lwcTester` shall verify that `sfdx-lwc-jest`, `apexcharts`, and `jest-canvas-mock` are installed in `node_modules`, install any missing packages, run Jest unit and integration tests from `test/lwcTester`, and enforce minimum coverage of 80% statements, 75% branches, 80% functions, and 80% lines before deployment.
+- Each agent's tests shall be runnable individually via npm scripts such as `npm run test:changeRequestGenerator`.
+- Each agent shall have a dedicated npm script. Pass the dashboard API name using `--dashboard=<name>` when running `dashboardRetriever` or `dashboardReader`.
+- A Node script named `sfdcDeployer` shall deploy metadata using the `sf` CLI and write a deployment report under `reports`.
 - Development tooling such as the Salesforce CLI and Jest shall be listed under `devDependencies` in `package.json` so `npm install` fully sets up the environment.
 
 ## Out of Scope

--- a/docs/agents/lwcTester.md
+++ b/docs/agents/lwcTester.md
@@ -18,7 +18,7 @@ Automates building, maintaining, and enhancing Jest-based unit and integration t
 ## Behavior
 
 1. **Authenticate**: Verifies Salesforce org authentication via `sfdcAuthorizer`.
-2. **Install & Update Tooling**: Installs/updates devDependencies (`sfdx-lwc-jest`, `apexcharts`, `jest-canvas-mock`). fileciteturn1file0
+2. **Install & Update Tooling**: Verifies `sfdx-lwc-jest`, `apexcharts`, and `jest-canvas-mock` exist under `node_modules` and installs them when missing. fileciteturn1file0
 3. **Scaffold Test Structure**: Creates `test/lwcTester/` with `unit/`, `integration/`, and `__mocks__/`.
 4. **Generate & Update Test Templates**: For each chart definition in `dynamicCharts.js` or `charts.json`, generates or refreshes parameterized Jest test files, verifying SAQL assembly, ApexCharts instantiation, filter UI interactions, and snapshot updates. fileciteturn1file0
 5. **Maintain Existing Tests**: Detects outdated or missing assertions, offers snapshot updates or placeholder specs. fileciteturn1file0

--- a/scripts/agents/lwcTester.js
+++ b/scripts/agents/lwcTester.js
@@ -1,33 +1,37 @@
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
-const authorize = require('./sfdcAuthorizer');
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+const authorize = require("./sfdcAuthorizer");
 
 function ensureDevDependencies() {
-  const pkgPath = path.resolve(process.cwd(), 'package.json');
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const pkgPath = path.resolve(process.cwd(), "package.json");
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
   const devDeps = pkg.devDependencies || {};
-  const needed = ['sfdx-lwc-jest', 'apexcharts', 'jest-canvas-mock'];
-  const missing = needed.filter((d) => !devDeps[d]);
+  const needed = ["sfdx-lwc-jest", "apexcharts", "jest-canvas-mock"];
+  const missingInPkg = needed.filter((d) => !devDeps[d]);
+  const missingOnDisk = needed.filter(
+    (d) => !fs.existsSync(path.join("node_modules", d))
+  );
+  const missing = Array.from(new Set([...missingInPkg, ...missingOnDisk]));
   if (missing.length) {
-    const cmd = `npm install --save-dev ${missing.join(' ')}`;
-    execSync(cmd, { stdio: 'inherit' });
+    const cmd = `npm install --save-dev ${missing.join(" ")}`;
+    execSync(cmd, { stdio: "inherit" });
   }
 }
 
-function ensureTestStructure(baseDir = 'test/lwcTester') {
-  ['unit', 'integration', '__mocks__', 'reports'].forEach((d) => {
+function ensureTestStructure(baseDir = "test/lwcTester") {
+  ["unit", "integration", "__mocks__", "reports"].forEach((d) => {
     fs.mkdirSync(path.join(baseDir, d), { recursive: true });
   });
 }
 
 function runTests({ unit, integration, ci } = {}) {
-  let script = 'npm run test:lwc:unit';
-  if (integration) script = 'npm run test:lwc:integration';
+  let script = "npm run test:lwc:unit";
+  if (integration) script = "npm run test:lwc:integration";
   if (ci) {
-    execSync('npm run lint', { stdio: 'inherit' });
+    execSync("npm run lint", { stdio: "inherit" });
   }
-  execSync(script, { stdio: 'inherit' });
+  execSync(script, { stdio: "inherit" });
 }
 
 function lwcTester(opts = {}) {
@@ -40,9 +44,9 @@ function lwcTester(opts = {}) {
 if (require.main === module) {
   const opts = {};
   process.argv.slice(2).forEach((arg) => {
-    if (arg === '--unit' || arg === '-u') opts.unit = true;
-    else if (arg === '--integration' || arg === '-i') opts.integration = true;
-    else if (arg === '--ci' || arg === '-c') opts.ci = true;
+    if (arg === "--unit" || arg === "-u") opts.unit = true;
+    else if (arg === "--integration" || arg === "-i") opts.integration = true;
+    else if (arg === "--ci" || arg === "-c") opts.ci = true;
   });
   lwcTester(opts);
 }
@@ -50,3 +54,4 @@ if (require.main === module) {
 module.exports = lwcTester;
 module.exports.ensureTestStructure = ensureTestStructure;
 module.exports.runTests = runTests;
+module.exports.ensureDevDependencies = ensureDevDependencies;

--- a/test/lwcTester.test.js
+++ b/test/lwcTester.test.js
@@ -1,39 +1,70 @@
-const fs = require('fs');
-const path = require('path');
-jest.mock('child_process', () => ({ execSync: jest.fn() }));
-const { execSync } = require('child_process');
+const fs = require("fs");
+const path = require("path");
+jest.mock("child_process", () => ({ execSync: jest.fn() }));
+const { execSync } = require("child_process");
 
-const tester = require('../scripts/agents/lwcTester');
+const tester = require("../scripts/agents/lwcTester");
 
-describe('lwcTester', () => {
-  const baseDir = path.join(__dirname, 'lwcTester');
+describe("lwcTester", () => {
+  const baseDir = path.join(__dirname, "lwcTester");
 
   beforeEach(() => {
     fs.rmSync(baseDir, { recursive: true, force: true });
     jest.clearAllMocks();
   });
 
-  test('creates test folder structure', () => {
+  test("creates test folder structure", () => {
     tester.ensureTestStructure(baseDir);
-    expect(fs.existsSync(path.join(baseDir, 'unit'))).toBe(true);
-    expect(fs.existsSync(path.join(baseDir, 'integration'))).toBe(true);
-    expect(fs.existsSync(path.join(baseDir, '__mocks__'))).toBe(true);
-    expect(fs.existsSync(path.join(baseDir, 'reports'))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, "unit"))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, "integration"))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, "__mocks__"))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, "reports"))).toBe(true);
   });
 
-  test('runs unit tests by default', () => {
+  test("installs missing dev dependencies when node_modules is empty", () => {
+    const tmp = fs.mkdtempSync(path.join(__dirname, "deps-"));
+    fs.writeFileSync(
+      path.join(tmp, "package.json"),
+      JSON.stringify({
+        devDependencies: {
+          "sfdx-lwc-jest": "1.0.0",
+          apexcharts: "1.0.0",
+          "jest-canvas-mock": "1.0.0"
+        }
+      })
+    );
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    tester.ensureDevDependencies();
+    process.chdir(cwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+    expect(execSync).toHaveBeenCalledWith(
+      "npm install --save-dev sfdx-lwc-jest apexcharts jest-canvas-mock",
+      { stdio: "inherit" }
+    );
+  });
+
+  test("runs unit tests by default", () => {
     tester.runTests();
-    expect(execSync).toHaveBeenCalledWith('npm run test:lwc:unit', { stdio: 'inherit' });
+    expect(execSync).toHaveBeenCalledWith("npm run test:lwc:unit", {
+      stdio: "inherit"
+    });
   });
 
-  test('runs integration tests when flag provided', () => {
+  test("runs integration tests when flag provided", () => {
     tester.runTests({ integration: true });
-    expect(execSync).toHaveBeenCalledWith('npm run test:lwc:integration', { stdio: 'inherit' });
+    expect(execSync).toHaveBeenCalledWith("npm run test:lwc:integration", {
+      stdio: "inherit"
+    });
   });
 
-  test('runs lint in ci mode', () => {
+  test("runs lint in ci mode", () => {
     tester.runTests({ ci: true });
-    expect(execSync).toHaveBeenNthCalledWith(1, 'npm run lint', { stdio: 'inherit' });
-    expect(execSync).toHaveBeenNthCalledWith(2, 'npm run test:lwc:unit', { stdio: 'inherit' });
+    expect(execSync).toHaveBeenNthCalledWith(1, "npm run lint", {
+      stdio: "inherit"
+    });
+    expect(execSync).toHaveBeenNthCalledWith(2, "npm run test:lwc:unit", {
+      stdio: "inherit"
+    });
   });
 });


### PR DESCRIPTION
## Summary
- verify dev dependencies exist in `node_modules` before running tests
- export `ensureDevDependencies`
- test installing missing packages when `node_modules` is empty
- document package installation step for lwcTester
- update design and requirements docs

## Testing
- `npm run test:lwcTester`

------
https://chatgpt.com/codex/tasks/task_e_685029115b388327aa8edb2db5cddffe