### PR TITLE
Support newline terminator in chart styles

### DIFF
--- a/DASHBOARD_PARSING_INSTRUCTIONS.MD
+++ b/DASHBOARD_PARSING_INSTRUCTIONS.MD
@@ -14,7 +14,8 @@
 5. **Text Widget** The widget immediately to the right of each chart contains the chart style configuration.
 
     * Style Format:
-        - Semi-colon separated fields using CSS-like syntax: `type: bar; colors: red,blue; title: Monthly Revenue; x-axis-font-size: 10pt; y-axis-font-size: 10pt; font-color: dark grey`
+        - Fields may be separated by semicolons **or** newlines using CSS-like syntax: `type: bar; colors: red,blue`.
+        - Example: `title: Monthly Revenue\nfont-color: dark grey` is equivalent to using semicolons.
 
 6. **Color Schema** Use the `Color Schema` below to map color names to specific hex values. Any colors not mentioned should be assumed to be CSS colors and passed through as they are
 

--- a/docs/SystemDesign.md
+++ b/docs/SystemDesign.md
@@ -37,7 +37,7 @@ All automation scripts assume a Node.js 18 or later runtime (tested with Node.js
 
 - **dynamicCharts.js**: Core logic for loading datasets, handling filter selections, generating SAQL, cross-filtering available options, and rendering six charts with ApexCharts.
 - The component applies visual effects such as drop shadows based on chart settings to enhance chart readability.
-- **dynamicCharts.html**: Presents filter controls and a left-hand list of chart names. Each chart pair appears on its own page that can be selected from this list. Pages are rendered with a two-column grid: charts on the left and a text widget on the right that supplies style metadata.
+- **dynamicCharts.html**: Presents filter controls and a left-hand list of chart names. Each chart pair appears on its own page that can be selected from this list. Pages are rendered with a two-column grid: charts on the left and a text widget on the right that supplies style metadata separated by semicolons or newlines.
 - **dynamicCharts.js-meta.xml**: Exposes the component to App, Record, and Home pages.
 - **DPOStateMachine.cls**: Placeholder Apex class reserved for future enhancements or server-side processing.
 - **charts.json**: Generated from the CRM Analytics dashboards to list supported charts. Primary charts are included, while `AO` variants are ignored.

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -18,7 +18,7 @@ Dynamic Charts is a Lightning application for Salesforce that enables users to q
    - A `dashboardReader` script shall convert exported dashboard JSON into normalized chart definitions.
    - The parser must handle dashboard files where the `widgets` section is either an array or a keyed object.
    - The parser shall detect error responses (objects with `errorCode`) and throw `Invalid dashboard JSON` to halt processing.
-   - Metadata describing each chart is now read from a text widget placed in the column to the right of the chart. The text widget uses CSS-style strings (`key: value;`) instead of the subtitle field.
+   - Metadata describing each chart is now read from a text widget placed in the column to the right of the chart. The text widget uses CSS-style strings (`key: value`) separated by semicolons or newlines instead of the subtitle field.
    - Parsed charts shall be written to `charts.json`, replacing previous definitions. Style attribute keys discovered in the text widgets shall be tracked in `chartStyles.txt`.
    - Widgets are processed in row-major order so chart widgets are encountered before their companion text widgets.
 4. **Component Analysis**

--- a/docs/agents/dashboardReader.md
+++ b/docs/agents/dashboardReader.md
@@ -43,7 +43,7 @@ This agent reads an extracted dashboard `state` JSON file and produces normalize
 ## Assumptions
 
 - `title` is converted to kebab-case and used as `chart.id`.
-- Style metadata is stored in a text widget positioned to the right of each chart. The text uses CSS-style syntax (`key: value;` pairs) and replaces the previous use of the subtitle field.
+- Style metadata is stored in a text widget positioned to the right of each chart. The text uses CSS-style syntax (`key: value`) and fields may be separated by semicolons or newlines. This replaces the previous use of the subtitle field.
 - Widgets are processed in row-major order so that each chart widget is followed by its companion text widget.
 - Color names not in the defined scheme are treated as valid CSS colors.
 - Missing charts in the new dashboard cause removal of their entries from `charts.json`. fileciteturn2file0

--- a/scripts/agents/dashboardReader.js
+++ b/scripts/agents/dashboardReader.js
@@ -64,10 +64,14 @@ function toKebab(str) {
 function parseStyleString(str) {
   const meta = {};
   if (!str) return meta;
-  str.split(";").forEach((pair) => {
-    const [key, value] = pair.split(pair.includes(":") ? ":" : "=").map((s) => s.trim());
-    if (key) meta[key.toLowerCase()] = value;
-  });
+  str
+    .split(/(?:;|\r?\n)+/)
+    .forEach((pair) => {
+      const [key, value] = pair
+        .split(pair.includes(":") ? ":" : "=")
+        .map((s) => s.trim());
+      if (key) meta[key.toLowerCase()] = value;
+    });
   return meta;
 }
 

--- a/test/dashboardReader.test.js
+++ b/test/dashboardReader.test.js
@@ -98,6 +98,57 @@ describe('dashboardReader', () => {
     expect(stylesText).toMatch(/colors/);
   });
 
+  test('parses text widget styles separated by newlines', () => {
+    const dashboard = {
+      state: {
+        widgets: {
+          w1: {
+            type: 'chart',
+            saql: 'saql1',
+            parameters: {
+              title: { label: 'Climbs By Nation' },
+              step: 'step1',
+              columnMap: { dimensionAxis: ['nation'], plots: ['A'] }
+            },
+            fieldMappings: { nation: 'Nation', Climbs: 'Climbs' }
+          },
+          w1desc: {
+            type: 'text',
+            parameters: {
+              content: { richTextContent: [{ insert: 'type: bar\ncolors: red\nshadow: true' }] }
+            }
+          }
+        },
+        steps: { step1: { query: 'saql1' } },
+        gridLayouts: [
+          {
+            pages: [
+              {
+                widgets: [
+                  { name: 'w1', column: 0, row: 1 },
+                  { name: 'w1desc', column: 1, row: 1 }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    };
+    fs.writeFileSync(inputFile, JSON.stringify(dashboard));
+
+    const result = readDashboard({
+      dashboardApiName: 'CR-02',
+      inputDir: tmpDir,
+      chartsFile,
+      chartStylesFile: stylesFile
+    });
+
+    const data = JSON.parse(fs.readFileSync(chartsFile, 'utf8'));
+    expect(data).toEqual(result);
+    expect(data.charts[0].style.seriesColors).toBe('#EF6B4D');
+    expect(data.charts[0].style.effects).toEqual(['shadow']);
+  });
+
   test('throws when file missing', () => {
     expect(() =>
       readDashboard({ dashboardApiName: 'CR-02', inputDir: tmpDir, chartsFile })


### PR DESCRIPTION
## Summary
- allow dashboardReader to parse newline-separated style instructions
- update design docs to document newline delimiters
- expand dashboardReader tests for newline separation

## Testing
- `npm run test:dashboardReader`

------
https://chatgpt.com/codex/tasks/task_e_6850627583cc83279cec97074a5ae134