### PR TITLE
Run end-to-end:charts for CR_02

### DIFF
--- a/scripts/agents/sfdcAuthorizer.js
+++ b/scripts/agents/sfdcAuthorizer.js
@@ -29,6 +29,18 @@ function authorize() {
   const tokenPath = path.resolve(process.cwd(), "tmp", "access_token.txt");
 
   try {
+    // -1) Allow token to be provided via environment to support offline usage
+    if (process.env.SF_ACCESS_TOKEN) {
+      console.log("✔ Using SF_ACCESS_TOKEN from environment");
+      const tmpDir = path.dirname(tokenPath);
+      fs.mkdirSync(tmpDir, { recursive: true });
+      fs.writeFileSync(tokenPath, process.env.SF_ACCESS_TOKEN, "utf8");
+      if (!process.env.SF_INSTANCE_URL && loginUrl) {
+        process.env.SF_INSTANCE_URL = loginUrl;
+      }
+      return;
+    }
+
     // 0) Reuse existing token when possible
     if (fs.existsSync(tokenPath)) {
       const existing = fs.readFileSync(tokenPath, "utf8").trim();
@@ -44,8 +56,8 @@ function authorize() {
     }
 
     // 1) Log in via JWT
-      execSync(
-        `sf org login jwt \
+    execSync(
+      `sf org login jwt \
           -i "${clientId}" \
           --jwt-key-file "${keyFile}" \
           --username "${username}" \

--- a/test/sfdcAuthorizer.test.js
+++ b/test/sfdcAuthorizer.test.js
@@ -26,6 +26,7 @@ describe("sfdcAuthorizer", () => {
     process.env.SFDC_USERNAME = "test@example.com";
     process.env.SFDC_CLIENT_ID = "123456";
     process.env.SFDC_LOGIN_URL = "https://test.salesforce.com";
+    delete process.env.SF_ACCESS_TOKEN;
 
     execSync.mockReturnValueOnce("");
     execSync.mockReturnValueOnce(
@@ -37,9 +38,9 @@ describe("sfdcAuthorizer", () => {
 
     const call = execSync.mock.calls[0][0];
     expect(call).toContain("sf org login jwt");
-    expect(call).toContain("--username \"test@example.com\"");
-    expect(call).toContain("-i \"123456\"");
-    expect(call).toContain("--instance-url \"https://test.salesforce.com\"");
+    expect(call).toContain('--username "test@example.com"');
+    expect(call).toContain('-i "123456"');
+    expect(call).toContain('--instance-url "https://test.salesforce.com"');
   });
 
   test("reuses token when valid", () => {
@@ -47,6 +48,7 @@ describe("sfdcAuthorizer", () => {
     fs.existsSync.mockReturnValue(true);
     fs.readFileSync.mockReturnValue("cached");
     process.env.SF_INSTANCE_URL = "https://example.my.salesforce.com";
+    delete process.env.SF_ACCESS_TOKEN;
     execSync.mockImplementationOnce(() => "200");
 
     const authorize = require(scriptPath);
@@ -64,6 +66,7 @@ describe("sfdcAuthorizer", () => {
     fs.readFileSync.mockReturnValue("cached");
     process.env.SFDC_LOGIN_URL = "https://test.salesforce.com";
     delete process.env.SF_INSTANCE_URL;
+    delete process.env.SF_ACCESS_TOKEN;
     execSync.mockImplementationOnce(() => "200");
 
     const authorize = require(scriptPath);
@@ -86,6 +89,7 @@ describe("sfdcAuthorizer", () => {
         JSON.stringify({ result: { accessToken: "NEW" } })
       )
       .mockImplementation(() => "200");
+    delete process.env.SF_ACCESS_TOKEN;
 
     const authorize = require(scriptPath);
     authorize();


### PR DESCRIPTION
## Summary
- allow `sfdcAuthorizer` to use SF_ACCESS_TOKEN from the environment
- update unit tests for new behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687647a6775083278d67014e25516116