### PR TITLE
Add lwcBuilder agent and tests

### DIFF
--- a/docs/agents/lwcBuilder.md
+++ b/docs/agents/lwcBuilder.md
@@ -4,4 +4,53 @@
 
 ## Description
 
-Automates building of LWC component `dynamicCharts` based on `Charts.json`. Parses Charts.json and references `https://apexcharts.com/docs/` for option json
+The `lwcBuilder` agent reads a `charts.json` file and generates the Lightning Web
+Component source for `dynamicCharts`. Chart definitions are converted into a
+`chartSettings` object in `dynamicCharts.js` and matching `<div>` placeholders in
+`dynamicCharts.html`. A basic `dynamicCharts.js-meta.xml` file is also
+produced. Style keys discovered in the chart definitions are compared against the
+ApexCharts option documentation at [apexcharts.com](https://apexcharts.com/docs/)
+to populate `chartStyles.txt` with descriptions of new options.
+
+## CLI Options
+
+- `--charts-file <path>`: Path to the input chart definition JSON (default:
+  `charts.json`).
+- `--output-dir <dir>`: Directory where the LWC files should be written
+  (default: `force-app/main/default/lwc/dynamicCharts`).
+- `--silent`: Suppress console output.
+- `-h`, `--help`: Show usage information.
+
+## Inputs
+
+- `chartsFile`: JSON file containing a `charts` array as documented in
+  `CHART_JSON_DEFINITION.MD`.
+- _(Optional)_ `outputDir`: Destination for the generated component files.
+- _(Optional)_ `silent`: Flag to reduce log verbosity.
+
+## Behavior
+
+1. Parse `chartsFile` and validate the result contains a `charts` array.
+2. Create `outputDir` if it does not already exist.
+3. Write `dynamicCharts.html` with a `<div>` element for each chart id.
+4. Write `dynamicCharts.js` exporting a `LightningElement` class with a
+   `chartSettings` property reflecting the chart definitions. The style section is
+   normalized so `seriesColors` becomes `colors` and `effects` is copied as-is.
+5. Write a minimal `dynamicCharts.js-meta.xml` that exposes the component to App,
+   Record and Home pages.
+6. For each style key encountered, fetch a short description from the ApexCharts
+   documentation site and append unknown keys to `chartStyles.txt`.
+7. Return an object describing the files that were written.
+
+## Output
+
+- `dynamicCharts.html`
+- `dynamicCharts.js`
+- `dynamicCharts.js-meta.xml`
+- Updated `chartStyles.txt`
+
+## Example
+
+```bash
+node scripts/agents/lwcBuilder.js --charts-file charts.json --output-dir force-app/main/default/lwc/dynamicCharts
+```

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "changeRequestGenerator": "node scripts/agents/changeRequestGenerator.js",
     "syncCharts": "node scripts/agents/syncCharts.js",
     "lwcTester": "node scripts/agents/lwcTester.js",
-    "sfdcDeployer": "node scripts/agents/sfdcDeployer.js"
+    "sfdcDeployer": "node scripts/agents/sfdcDeployer.js",
+    "lwcBuilder": "node scripts/agents/lwcBuilder.js"
   },
   "devDependencies": {
     "@lwc/eslint-plugin-lwc": "^2.2.0",

--- a/scripts/agents/lwcBuilder.js
+++ b/scripts/agents/lwcBuilder.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// scripts/agents/lwcBuilder.js
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+function fetchDescription(key) {
+  try {
+    const html = execSync(`curl -s https://apexcharts.com/docs/options/${key}/`, {
+      encoding: 'utf8'
+    });
+    const m = html.match(/<h1[^>]*>(.*?)<\/h1>/i) || html.match(/<title>(.*?)<\/title>/i);
+    return m ? m[1].trim() : 'ApexCharts option';
+  } catch {
+    return 'ApexCharts option';
+  }
+}
+
+function updateStyleReference(charts, file) {
+  if (!file) return;
+  const seen = fs.existsSync(file)
+    ? fs.readFileSync(file, 'utf8').split(/\n/).map(l => l.split(' - ')[0])
+    : [];
+  charts.forEach(chart => {
+    const style = chart.style || {};
+    Object.keys(style).forEach(k => {
+      if (!seen.includes(k)) {
+        const desc = fetchDescription(k);
+        fs.appendFileSync(file, `${k} - ${desc}\n`);
+        seen.push(k);
+      }
+    });
+  });
+}
+
+function buildLwc({ chartsFile = 'charts.json', outputDir = 'force-app/main/default/lwc/dynamicCharts', silent = false } = {}) {
+  if (!fs.existsSync(chartsFile)) {
+    throw new Error(`Charts file not found: ${chartsFile}`);
+  }
+  const chartsData = JSON.parse(fs.readFileSync(chartsFile, 'utf8'));
+  const charts = chartsData.charts || [];
+
+  const outDir = path.resolve(outputDir);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const htmlPath = path.join(outDir, 'dynamicCharts.html');
+  const jsPath = path.join(outDir, 'dynamicCharts.js');
+  const metaPath = path.join(outDir, 'dynamicCharts.js-meta.xml');
+
+  const htmlLines = ['<template>'];
+  charts.forEach(c => {
+    htmlLines.push(`  <div class="${c.id} slds-var-m-around_medium" lwc:dom="manual"></div>`);
+  });
+  htmlLines.push('</template>');
+  fs.writeFileSync(htmlPath, htmlLines.join('\n'));
+
+  const settings = {};
+  charts.forEach(c => {
+    const style = c.style || {};
+    const entry = {
+      dashboard: c.dashboard,
+      title: c.title,
+      fieldMappings: c.fieldMappings
+    };
+    if (style.seriesColors) entry.colors = style.seriesColors.split(',');
+    if (style.effects) entry.effects = style.effects;
+    settings[c.id] = entry;
+  });
+
+  const jsContent = `import { LightningElement } from 'lwc';
+
+export default class DynamicCharts extends LightningElement {
+  chartSettings = ${JSON.stringify(settings, null, 2)};
+}
+`;
+  fs.writeFileSync(jsPath, jsContent);
+
+  const metaContent = `<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>60.0</apiVersion>
+  <isExposed>true</isExposed>
+  <targets>
+    <target>lightning__AppPage</target>
+    <target>lightning__RecordPage</target>
+    <target>lightning__HomePage</target>
+  </targets>
+</LightningComponentBundle>`;
+  fs.writeFileSync(metaPath, metaContent);
+
+  updateStyleReference(charts, 'chartStyles.txt');
+
+  if (!silent) {
+    console.log(`✔ LWC files written to ${outDir}`);
+  }
+  return { htmlFile: htmlPath, jsFile: jsPath, metaFile: metaPath };
+}
+
+if (require.main === module) {
+  const opts = {};
+  process.argv.slice(2).forEach(arg => {
+    if (arg.startsWith('--charts-file=')) {
+      opts.chartsFile = arg.split('=')[1];
+    } else if (arg.startsWith('--output-dir=')) {
+      opts.outputDir = arg.split('=')[1];
+    } else if (arg === '--silent') {
+      opts.silent = true;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log('Usage: node lwcBuilder.js [--charts-file file] [--output-dir dir] [--silent]');
+      process.exit(0);
+    }
+  });
+  try {
+    buildLwc(opts);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = buildLwc;

--- a/test/lwcBuilder.test.js
+++ b/test/lwcBuilder.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const buildLwc = require('../scripts/agents/lwcBuilder');
+
+describe('lwcBuilder', () => {
+  const tmpDir = path.join(__dirname, 'lwcBuilder');
+  const chartsFile = path.join(tmpDir, 'charts.json');
+
+  beforeEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.copyFileSync(path.resolve(__dirname, '../charts.json'), chartsFile);
+  });
+
+  test('generates component files from charts', () => {
+    const result = buildLwc({ chartsFile, outputDir: tmpDir, silent: true });
+    expect(fs.existsSync(result.htmlFile)).toBe(true);
+    expect(fs.existsSync(result.jsFile)).toBe(true);
+    expect(fs.existsSync(result.metaFile)).toBe(true);
+    const js = fs.readFileSync(result.jsFile, 'utf8');
+    const html = fs.readFileSync(result.htmlFile, 'utf8');
+    expect(js).toMatch(/chartSettings/);
+    expect(js).toMatch(/climbs-by-nation/);
+    expect(html).toMatch(/climbs-by-nation/);
+  });
+
+  test('throws when charts file missing', () => {
+    fs.unlinkSync(chartsFile);
+    expect(() => buildLwc({ chartsFile, outputDir: tmpDir })).toThrow(/Charts file not found/);
+  });
+
+  test('uses defaults when no options passed', () => {
+    const cwd = process.cwd();
+    const projDir = path.join(tmpDir, 'proj');
+    fs.mkdirSync(projDir, { recursive: true });
+    fs.copyFileSync(chartsFile, path.join(projDir, 'charts.json'));
+    process.chdir(projDir);
+    try {
+      buildLwc();
+      const jsPath = path.join(projDir, 'force-app/main/default/lwc/dynamicCharts/dynamicCharts.js');
+      expect(fs.existsSync(jsPath)).toBe(true);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- flesh out `lwcBuilder` documentation
- implement `lwcBuilder.js` script
- add Jest tests for the new agent
- expose `lwcBuilder` via npm scripts

## Testing
- `npm test` *(fails: LWC1075 errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_687d4f3365c883278b6fd1056e4c7597