### PR TITLE
Align lwcBuilder with example component

### DIFF
--- a/docs/agents/lwcBuilder.md
+++ b/docs/agents/lwcBuilder.md
@@ -32,10 +32,11 @@ to populate `chartStyles.txt` with descriptions of new options.
 
 1. Parse `chartsFile` and validate the result contains a `charts` array.
 2. Create `outputDir` if it does not already exist.
-3. Write `dynamicCharts.html` with a `<div>` element for each chart id.
-4. Write `dynamicCharts.js` exporting a `LightningElement` class with a
-   `chartSettings` property reflecting the chart definitions. The style section is
-   normalized so `seriesColors` becomes `colors` and `effects` is copied as-is.
+3. Copy `dynamicChartsExample.html` to `dynamicCharts.html`.
+4. Copy `dynamicChartsExample.js` to `dynamicCharts.js` and replace its
+   `chartSettings` object with one derived from the chart definitions. The style
+   section is normalized so `seriesColors` becomes `colors` and `effects` is
+   copied as-is.
 5. Write a minimal `dynamicCharts.js-meta.xml` that exposes the component to App,
    Record and Home pages.
 6. For each style key encountered, fetch a short description from the ApexCharts

--- a/scripts/agents/lwcBuilder.js
+++ b/scripts/agents/lwcBuilder.js
@@ -5,6 +5,9 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
+// LWC templates live in the project under force-app/main/default/lwc/dynamicCharts.
+// `dynamicChartsExample.html` and `dynamicChartsExample.js` provide the full
+// component implementation used as the basis for generated output.
 const TEMPLATE_DIR = path.join(
   __dirname,
   '..',


### PR DESCRIPTION
## Summary
- clarify that LWC templates come from `dynamicChartsExample.*`
- document new behavior for `lwcBuilder` that copies the example templates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e2fed1db883278ac1922464ba10ec